### PR TITLE
feat: prompts

### DIFF
--- a/internal/adapters/sqlite_db/migrations/003_create_prompts.sql
+++ b/internal/adapters/sqlite_db/migrations/003_create_prompts.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+CREATE TABLE prompts (
+    id         TEXT PRIMARY KEY,
+    name       TEXT NOT NULL,
+    content    TEXT NOT NULL DEFAULT '',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- +goose Down
+DROP TABLE prompts;

--- a/internal/adapters/sqlite_prompt/repository.go
+++ b/internal/adapters/sqlite_prompt/repository.go
@@ -1,0 +1,121 @@
+package sqliteprompt
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/google/uuid"
+
+	apperrors "github.com/DEEJ4Y/genkitkraft/internal/common/errors"
+	"github.com/DEEJ4Y/genkitkraft/internal/domain/prompt"
+	promptrepo "github.com/DEEJ4Y/genkitkraft/internal/ports/prompt_repo"
+)
+
+// Compile-time check that PromptRepository implements the port interface.
+var _ promptrepo.PromptRepository = (*PromptRepository)(nil)
+
+// PromptRepository implements promptrepo.PromptRepository using SQLite.
+type PromptRepository struct {
+	db *sql.DB
+}
+
+// NewPromptRepository creates a new SQLite-backed prompt repository.
+func NewPromptRepository(db *sql.DB) *PromptRepository {
+	return &PromptRepository{db: db}
+}
+
+func (r *PromptRepository) List(ctx context.Context, limit, offset int) ([]*prompt.Prompt, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, name, content, created_at, updated_at
+		 FROM prompts ORDER BY created_at DESC LIMIT ? OFFSET ?`, limit, offset)
+	if err != nil {
+		return nil, apperrors.NewAppErrorf(apperrors.Internal, "listing prompts: %v", err)
+	}
+	defer rows.Close()
+
+	var prompts []*prompt.Prompt
+	for rows.Next() {
+		var p prompt.Prompt
+		if err := rows.Scan(&p.ID, &p.Name, &p.Content, &p.CreatedAt, &p.UpdatedAt); err != nil {
+			return nil, apperrors.NewAppErrorf(apperrors.Internal, "scanning prompt: %v", err)
+		}
+		prompts = append(prompts, &p)
+	}
+	return prompts, rows.Err()
+}
+
+func (r *PromptRepository) Count(ctx context.Context) (int, error) {
+	var count int
+	err := r.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM prompts`).Scan(&count)
+	if err != nil {
+		return 0, apperrors.NewAppErrorf(apperrors.Internal, "counting prompts: %v", err)
+	}
+	return count, nil
+}
+
+func (r *PromptRepository) GetByID(ctx context.Context, id string) (*prompt.Prompt, error) {
+	var p prompt.Prompt
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id, name, content, created_at, updated_at
+		 FROM prompts WHERE id = ?`, id).Scan(&p.ID, &p.Name, &p.Content, &p.CreatedAt, &p.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, apperrors.NewAppError(apperrors.NotFound, "prompt not found")
+	}
+	if err != nil {
+		return nil, apperrors.NewAppErrorf(apperrors.Internal, "getting prompt: %v", err)
+	}
+	return &p, nil
+}
+
+func (r *PromptRepository) Create(ctx context.Context, p *prompt.Prompt) error {
+	p.ID = uuid.New().String()
+	now := time.Now().UTC()
+	p.CreatedAt = now
+	p.UpdatedAt = now
+
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO prompts (id, name, content, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?)`,
+		p.ID, p.Name, p.Content, p.CreatedAt, p.UpdatedAt)
+	if err != nil {
+		return apperrors.NewAppErrorf(apperrors.Internal, "creating prompt: %v", err)
+	}
+	return nil
+}
+
+func (r *PromptRepository) Update(ctx context.Context, p *prompt.Prompt) error {
+	p.UpdatedAt = time.Now().UTC()
+
+	result, err := r.db.ExecContext(ctx,
+		`UPDATE prompts SET name = ?, content = ?, updated_at = ? WHERE id = ?`,
+		p.Name, p.Content, p.UpdatedAt, p.ID)
+	if err != nil {
+		return apperrors.NewAppErrorf(apperrors.Internal, "updating prompt: %v", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return apperrors.NewAppErrorf(apperrors.Internal, "checking update result: %v", err)
+	}
+	if rows == 0 {
+		return apperrors.NewAppError(apperrors.NotFound, "prompt not found")
+	}
+	return nil
+}
+
+func (r *PromptRepository) Delete(ctx context.Context, id string) error {
+	result, err := r.db.ExecContext(ctx, `DELETE FROM prompts WHERE id = ?`, id)
+	if err != nil {
+		return apperrors.NewAppErrorf(apperrors.Internal, "deleting prompt: %v", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return apperrors.NewAppErrorf(apperrors.Internal, "checking delete result: %v", err)
+	}
+	if rows == 0 {
+		return apperrors.NewAppError(apperrors.NotFound, "prompt not found")
+	}
+	return nil
+}

--- a/internal/api/gen/server.gen.go
+++ b/internal/api/gen/server.gen.go
@@ -26,6 +26,21 @@ type ServerInterface interface {
 	// Auth status
 	// (GET /api/auth/status)
 	GetAuthStatus(w http.ResponseWriter, r *http.Request)
+	// List prompts
+	// (GET /api/v1/prompts)
+	ListPrompts(w http.ResponseWriter, r *http.Request, params ListPromptsParams)
+	// Create prompt
+	// (POST /api/v1/prompts)
+	CreatePrompt(w http.ResponseWriter, r *http.Request)
+	// Delete prompt
+	// (DELETE /api/v1/prompts/{id})
+	DeletePrompt(w http.ResponseWriter, r *http.Request, id string)
+	// Get prompt
+	// (GET /api/v1/prompts/{id})
+	GetPrompt(w http.ResponseWriter, r *http.Request, id string)
+	// Update prompt
+	// (PUT /api/v1/prompts/{id})
+	UpdatePrompt(w http.ResponseWriter, r *http.Request, id string)
 	// List provider types
 	// (GET /api/v1/provider-types)
 	ListProviderTypes(w http.ResponseWriter, r *http.Request)
@@ -111,6 +126,130 @@ func (siw *ServerInterfaceWrapper) GetAuthStatus(w http.ResponseWriter, r *http.
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetAuthStatus(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListPrompts operation middleware
+func (siw *ServerInterfaceWrapper) ListPrompts(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListPromptsParams
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameter("form", false, false, "limit", r.URL.Query(), &params.Limit)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "offset" -------------
+
+	err = runtime.BindQueryParameter("form", false, false, "offset", r.URL.Query(), &params.Offset)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "offset", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListPrompts(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreatePrompt operation middleware
+func (siw *ServerInterfaceWrapper) CreatePrompt(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreatePrompt(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeletePrompt operation middleware
+func (siw *ServerInterfaceWrapper) DeletePrompt(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeletePrompt(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetPrompt operation middleware
+func (siw *ServerInterfaceWrapper) GetPrompt(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetPrompt(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdatePrompt operation middleware
+func (siw *ServerInterfaceWrapper) UpdatePrompt(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdatePrompt(w, r, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -414,6 +553,11 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("POST "+options.BaseURL+"/api/auth/logout", wrapper.Logout)
 	m.HandleFunc("GET "+options.BaseURL+"/api/auth/me", wrapper.GetMe)
 	m.HandleFunc("GET "+options.BaseURL+"/api/auth/status", wrapper.GetAuthStatus)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/prompts", wrapper.ListPrompts)
+	m.HandleFunc("POST "+options.BaseURL+"/api/v1/prompts", wrapper.CreatePrompt)
+	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/prompts/{id}", wrapper.DeletePrompt)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/prompts/{id}", wrapper.GetPrompt)
+	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/prompts/{id}", wrapper.UpdatePrompt)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/provider-types", wrapper.ListProviderTypes)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/settings/providers", wrapper.ListProviders)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/settings/providers", wrapper.CreateProvider)

--- a/internal/api/gen/types.gen.go
+++ b/internal/api/gen/types.gen.go
@@ -15,16 +15,17 @@ const (
 
 // Defines values for ModelsProviderType.
 const (
-	Anthropic      ModelsProviderType = "anthropic"
-	AzureAiFoundry ModelsProviderType = "azure_ai_foundry"
-	AzureOpenai    ModelsProviderType = "azure_openai"
-	Bedrock        ModelsProviderType = "bedrock"
-	Deepseek       ModelsProviderType = "deepseek"
-	GoogleAi       ModelsProviderType = "google_ai"
-	Ollama         ModelsProviderType = "ollama"
-	Openai         ModelsProviderType = "openai"
-	VertexAi       ModelsProviderType = "vertex_ai"
-	Xai            ModelsProviderType = "xai"
+	Anthropic        ModelsProviderType = "anthropic"
+	AzureAiFoundry   ModelsProviderType = "azure_ai_foundry"
+	AzureOpenai      ModelsProviderType = "azure_openai"
+	Bedrock          ModelsProviderType = "bedrock"
+	Deepseek         ModelsProviderType = "deepseek"
+	GoogleAi         ModelsProviderType = "google_ai"
+	Ollama           ModelsProviderType = "ollama"
+	Openai           ModelsProviderType = "openai"
+	OpenaiCompatible ModelsProviderType = "openai_compatible"
+	VertexAi         ModelsProviderType = "vertex_ai"
+	Xai              ModelsProviderType = "xai"
 )
 
 // ModelsAuthStatusResponse Response indicating whether authentication is required.
@@ -49,6 +50,15 @@ type ModelsConfigFieldInfo struct {
 
 	// Sensitive Whether the field contains sensitive data.
 	Sensitive *bool `json:"sensitive,omitempty"`
+}
+
+// ModelsCreatePromptRequest Request to create a new prompt.
+type ModelsCreatePromptRequest struct {
+	// Content Prompt content in markdown format.
+	Content string `json:"content"`
+
+	// Name Display name for this prompt.
+	Name string `json:"name"`
 }
 
 // ModelsCreateProviderRequest Request to create a new provider configuration.
@@ -111,6 +121,39 @@ type ModelsLogoutResponse struct {
 type ModelsMeResponse struct {
 	// Username Username of the currently authenticated user.
 	Username string `json:"username"`
+}
+
+// ModelsPromptListResponse Paginated list of prompts.
+type ModelsPromptListResponse struct {
+	// Limit Number of prompts per page.
+	Limit int32 `json:"limit"`
+
+	// Offset Number of prompts skipped.
+	Offset int32 `json:"offset"`
+
+	// Prompts Array of prompts.
+	Prompts []ModelsPromptResponse `json:"prompts"`
+
+	// Total Total number of prompts.
+	Total int32 `json:"total"`
+}
+
+// ModelsPromptResponse A prompt (system instruction) for an agent.
+type ModelsPromptResponse struct {
+	// Content Prompt content in markdown format.
+	Content string `json:"content"`
+
+	// CreatedAt When this prompt was created.
+	CreatedAt time.Time `json:"createdAt"`
+
+	// Id Unique prompt ID.
+	Id string `json:"id"`
+
+	// Name Display name for this prompt.
+	Name string `json:"name"`
+
+	// UpdatedAt When this prompt was last updated.
+	UpdatedAt time.Time `json:"updatedAt"`
 }
 
 // ModelsProviderListResponse List of configured providers.
@@ -197,6 +240,15 @@ type ModelsTestProviderResponse struct {
 	Success bool `json:"success"`
 }
 
+// ModelsUpdatePromptRequest Request to update an existing prompt.
+type ModelsUpdatePromptRequest struct {
+	// Content Updated prompt content in markdown format.
+	Content *string `json:"content,omitempty"`
+
+	// Name Updated display name.
+	Name *string `json:"name,omitempty"`
+}
+
 // ModelsUpdateProviderRequest Request to update an existing provider configuration.
 type ModelsUpdateProviderRequest struct {
 	// ApiKey New API key (leave blank to keep existing).
@@ -215,8 +267,20 @@ type ModelsUpdateProviderRequest struct {
 	Name *string `json:"name,omitempty"`
 }
 
+// ListPromptsParams defines parameters for ListPrompts.
+type ListPromptsParams struct {
+	Limit  *int32 `form:"limit,omitempty" json:"limit,omitempty"`
+	Offset *int32 `form:"offset,omitempty" json:"offset,omitempty"`
+}
+
 // LoginJSONRequestBody defines body for Login for application/json ContentType.
 type LoginJSONRequestBody = ModelsLoginRequest
+
+// CreatePromptJSONRequestBody defines body for CreatePrompt for application/json ContentType.
+type CreatePromptJSONRequestBody = ModelsCreatePromptRequest
+
+// UpdatePromptJSONRequestBody defines body for UpdatePrompt for application/json ContentType.
+type UpdatePromptJSONRequestBody = ModelsUpdatePromptRequest
 
 // CreateProviderJSONRequestBody defines body for CreateProvider for application/json ContentType.
 type CreateProviderJSONRequestBody = ModelsCreateProviderRequest

--- a/internal/app/commands/create_prompt.go
+++ b/internal/app/commands/create_prompt.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"context"
+
+	"github.com/DEEJ4Y/genkitkraft/internal/common/errors"
+	"github.com/DEEJ4Y/genkitkraft/internal/domain/prompt"
+	promptrepo "github.com/DEEJ4Y/genkitkraft/internal/ports/prompt_repo"
+)
+
+type CreatePromptParams struct {
+	Name    string
+	Content string
+}
+
+type CreatePromptResult struct {
+	Prompt *prompt.Prompt
+}
+
+type CreatePromptCommand struct {
+	repo promptrepo.PromptRepository
+}
+
+func NewCreatePromptCommand(repo promptrepo.PromptRepository) *CreatePromptCommand {
+	return &CreatePromptCommand{repo: repo}
+}
+
+func (c *CreatePromptCommand) Execute(ctx context.Context, params CreatePromptParams) (CreatePromptResult, error) {
+	if params.Name == "" {
+		return CreatePromptResult{}, errors.NewAppError(errors.InvalidInput, "name is required")
+	}
+
+	p := &prompt.Prompt{
+		Name:    params.Name,
+		Content: params.Content,
+	}
+
+	if err := c.repo.Create(ctx, p); err != nil {
+		return CreatePromptResult{}, err
+	}
+
+	return CreatePromptResult{Prompt: p}, nil
+}

--- a/internal/app/commands/delete_prompt.go
+++ b/internal/app/commands/delete_prompt.go
@@ -1,0 +1,23 @@
+package commands
+
+import (
+	"context"
+
+	promptrepo "github.com/DEEJ4Y/genkitkraft/internal/ports/prompt_repo"
+)
+
+type DeletePromptParams struct {
+	ID string
+}
+
+type DeletePromptCommand struct {
+	repo promptrepo.PromptRepository
+}
+
+func NewDeletePromptCommand(repo promptrepo.PromptRepository) *DeletePromptCommand {
+	return &DeletePromptCommand{repo: repo}
+}
+
+func (c *DeletePromptCommand) Execute(ctx context.Context, params DeletePromptParams) error {
+	return c.repo.Delete(ctx, params.ID)
+}

--- a/internal/app/commands/update_prompt.go
+++ b/internal/app/commands/update_prompt.go
@@ -1,0 +1,46 @@
+package commands
+
+import (
+	"context"
+
+	"github.com/DEEJ4Y/genkitkraft/internal/domain/prompt"
+	promptrepo "github.com/DEEJ4Y/genkitkraft/internal/ports/prompt_repo"
+)
+
+type UpdatePromptParams struct {
+	ID      string
+	Name    *string
+	Content *string
+}
+
+type UpdatePromptResult struct {
+	Prompt *prompt.Prompt
+}
+
+type UpdatePromptCommand struct {
+	repo promptrepo.PromptRepository
+}
+
+func NewUpdatePromptCommand(repo promptrepo.PromptRepository) *UpdatePromptCommand {
+	return &UpdatePromptCommand{repo: repo}
+}
+
+func (c *UpdatePromptCommand) Execute(ctx context.Context, params UpdatePromptParams) (UpdatePromptResult, error) {
+	p, err := c.repo.GetByID(ctx, params.ID)
+	if err != nil {
+		return UpdatePromptResult{}, err
+	}
+
+	if params.Name != nil {
+		p.Name = *params.Name
+	}
+	if params.Content != nil {
+		p.Content = *params.Content
+	}
+
+	if err := c.repo.Update(ctx, p); err != nil {
+		return UpdatePromptResult{}, err
+	}
+
+	return UpdatePromptResult{Prompt: p}, nil
+}

--- a/internal/app/prompt_app.go
+++ b/internal/app/prompt_app.go
@@ -1,0 +1,24 @@
+package app
+
+import (
+	"github.com/DEEJ4Y/genkitkraft/internal/app/commands"
+	"github.com/DEEJ4Y/genkitkraft/internal/app/executors"
+	"github.com/DEEJ4Y/genkitkraft/internal/app/queries"
+)
+
+// PromptApp groups all prompt management use cases.
+type PromptApp struct {
+	Commands PromptCommands
+	Queries  PromptQueries
+}
+
+type PromptCommands struct {
+	CreatePrompt executors.ExecutorWithReturn[commands.CreatePromptParams, commands.CreatePromptResult]
+	UpdatePrompt executors.ExecutorWithReturn[commands.UpdatePromptParams, commands.UpdatePromptResult]
+	DeletePrompt executors.Executor[commands.DeletePromptParams]
+}
+
+type PromptQueries struct {
+	ListPrompts executors.ExecutorWithReturn[queries.ListPromptsParams, queries.ListPromptsResult]
+	GetPrompt   executors.ExecutorWithReturn[queries.GetPromptParams, queries.GetPromptResult]
+}

--- a/internal/app/queries/get_prompt.go
+++ b/internal/app/queries/get_prompt.go
@@ -1,0 +1,32 @@
+package queries
+
+import (
+	"context"
+
+	"github.com/DEEJ4Y/genkitkraft/internal/domain/prompt"
+	promptrepo "github.com/DEEJ4Y/genkitkraft/internal/ports/prompt_repo"
+)
+
+type GetPromptParams struct {
+	ID string
+}
+
+type GetPromptResult struct {
+	Prompt *prompt.Prompt
+}
+
+type GetPromptQuery struct {
+	repo promptrepo.PromptRepository
+}
+
+func NewGetPromptQuery(repo promptrepo.PromptRepository) *GetPromptQuery {
+	return &GetPromptQuery{repo: repo}
+}
+
+func (q *GetPromptQuery) Execute(ctx context.Context, params GetPromptParams) (GetPromptResult, error) {
+	p, err := q.repo.GetByID(ctx, params.ID)
+	if err != nil {
+		return GetPromptResult{}, err
+	}
+	return GetPromptResult{Prompt: p}, nil
+}

--- a/internal/app/queries/list_prompts.go
+++ b/internal/app/queries/list_prompts.go
@@ -1,0 +1,56 @@
+package queries
+
+import (
+	"context"
+
+	"github.com/DEEJ4Y/genkitkraft/internal/domain/prompt"
+	promptrepo "github.com/DEEJ4Y/genkitkraft/internal/ports/prompt_repo"
+)
+
+type ListPromptsParams struct {
+	Limit  int
+	Offset int
+}
+
+type ListPromptsResult struct {
+	Prompts []*prompt.Prompt
+	Total   int
+}
+
+type ListPromptsQuery struct {
+	repo promptrepo.PromptRepository
+}
+
+func NewListPromptsQuery(repo promptrepo.PromptRepository) *ListPromptsQuery {
+	return &ListPromptsQuery{repo: repo}
+}
+
+func (q *ListPromptsQuery) Execute(ctx context.Context, params ListPromptsParams) (ListPromptsResult, error) {
+	limit := params.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	offset := params.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	total, err := q.repo.Count(ctx)
+	if err != nil {
+		return ListPromptsResult{}, err
+	}
+
+	prompts, err := q.repo.List(ctx, limit, offset)
+	if err != nil {
+		return ListPromptsResult{}, err
+	}
+
+	return ListPromptsResult{
+		Prompts: prompts,
+		Total:   total,
+	}, nil
+}

--- a/internal/domain/prompt/entity.go
+++ b/internal/domain/prompt/entity.go
@@ -1,0 +1,12 @@
+package prompt
+
+import "time"
+
+// Prompt represents a system instruction for an agent.
+type Prompt struct {
+	ID        string
+	Name      string
+	Content   string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}

--- a/internal/handlers/http_handler/handler.go
+++ b/internal/handlers/http_handler/handler.go
@@ -21,10 +21,11 @@ var _ gen.ServerInterface = (*Handler)(nil)
 type Handler struct {
 	authApp     *app.AuthApp
 	providerApp *app.ProviderApp
+	promptApp   *app.PromptApp
 }
 
-func NewHandler(authApp *app.AuthApp, providerApp *app.ProviderApp) *Handler {
-	return &Handler{authApp: authApp, providerApp: providerApp}
+func NewHandler(authApp *app.AuthApp, providerApp *app.ProviderApp, promptApp *app.PromptApp) *Handler {
+	return &Handler{authApp: authApp, providerApp: providerApp, promptApp: promptApp}
 }
 
 func (h *Handler) GetAuthStatus(w http.ResponseWriter, r *http.Request) {
@@ -197,4 +198,66 @@ func (h *Handler) TestProvider(w http.ResponseWriter, r *http.Request, id string
 		Success: result.Success,
 		Message: result.Message,
 	})
+}
+
+func (h *Handler) ListPrompts(w http.ResponseWriter, r *http.Request, params gen.ListPromptsParams) {
+	qParams := toListPromptsParams(params)
+	result, err := h.promptApp.Queries.ListPrompts.Execute(r.Context(), qParams)
+	if err != nil {
+		writeAppError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, toPromptListResponse(result, qParams.Limit, qParams.Offset))
+}
+
+func (h *Handler) CreatePrompt(w http.ResponseWriter, r *http.Request) {
+	var req gen.ModelsCreatePromptRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeAppError(w, errors.NewAppError(errors.InvalidInput, "invalid request body"))
+		return
+	}
+
+	params := toCreatePromptParams(req)
+	result, err := h.promptApp.Commands.CreatePrompt.Execute(r.Context(), params)
+	if err != nil {
+		writeAppError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, toPromptResponse(result.Prompt))
+}
+
+func (h *Handler) GetPrompt(w http.ResponseWriter, r *http.Request, id string) {
+	result, err := h.promptApp.Queries.GetPrompt.Execute(r.Context(), queries.GetPromptParams{ID: id})
+	if err != nil {
+		writeAppError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, toPromptResponse(result.Prompt))
+}
+
+func (h *Handler) UpdatePrompt(w http.ResponseWriter, r *http.Request, id string) {
+	var req gen.ModelsUpdatePromptRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeAppError(w, errors.NewAppError(errors.InvalidInput, "invalid request body"))
+		return
+	}
+
+	params := toUpdatePromptParams(id, req)
+	result, err := h.promptApp.Commands.UpdatePrompt.Execute(r.Context(), params)
+	if err != nil {
+		writeAppError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toPromptResponse(result.Prompt))
+}
+
+func (h *Handler) DeletePrompt(w http.ResponseWriter, r *http.Request, id string) {
+	err := h.promptApp.Commands.DeletePrompt.Execute(r.Context(), commands.DeletePromptParams{ID: id})
+	if err != nil {
+		writeAppError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/handlers/http_handler/type_conversion.go
+++ b/internal/handlers/http_handler/type_conversion.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DEEJ4Y/genkitkraft/internal/app/commands"
 	"github.com/DEEJ4Y/genkitkraft/internal/app/queries"
 	"github.com/DEEJ4Y/genkitkraft/internal/common/errors"
+	"github.com/DEEJ4Y/genkitkraft/internal/domain/prompt"
 	"github.com/DEEJ4Y/genkitkraft/internal/domain/provider"
 )
 
@@ -116,6 +117,59 @@ func toUpdateProviderParams(id string, req gen.ModelsUpdateProviderRequest) comm
 		BaseURL: req.BaseUrl,
 		Config:  req.Config,
 		Enabled: req.Enabled,
+	}
+}
+
+func toPromptResponse(p *prompt.Prompt) gen.ModelsPromptResponse {
+	return gen.ModelsPromptResponse{
+		Id:        p.ID,
+		Name:      p.Name,
+		Content:   p.Content,
+		CreatedAt: p.CreatedAt,
+		UpdatedAt: p.UpdatedAt,
+	}
+}
+
+func toPromptListResponse(result queries.ListPromptsResult, limit, offset int) gen.ModelsPromptListResponse {
+	prompts := make([]gen.ModelsPromptResponse, len(result.Prompts))
+	for i, p := range result.Prompts {
+		prompts[i] = toPromptResponse(p)
+	}
+	return gen.ModelsPromptListResponse{
+		Prompts: prompts,
+		Total:   int32(result.Total),
+		Limit:   int32(limit),
+		Offset:  int32(offset),
+	}
+}
+
+func toCreatePromptParams(req gen.ModelsCreatePromptRequest) commands.CreatePromptParams {
+	return commands.CreatePromptParams{
+		Name:    req.Name,
+		Content: req.Content,
+	}
+}
+
+func toUpdatePromptParams(id string, req gen.ModelsUpdatePromptRequest) commands.UpdatePromptParams {
+	return commands.UpdatePromptParams{
+		ID:      id,
+		Name:    req.Name,
+		Content: req.Content,
+	}
+}
+
+func toListPromptsParams(params gen.ListPromptsParams) queries.ListPromptsParams {
+	limit := 20
+	offset := 0
+	if params.Limit != nil {
+		limit = int(*params.Limit)
+	}
+	if params.Offset != nil {
+		offset = int(*params.Offset)
+	}
+	return queries.ListPromptsParams{
+		Limit:  limit,
+		Offset: offset,
 	}
 }
 

--- a/internal/ports/prompt_repo/port.go
+++ b/internal/ports/prompt_repo/port.go
@@ -1,0 +1,17 @@
+package promptrepo
+
+import (
+	"context"
+
+	"github.com/DEEJ4Y/genkitkraft/internal/domain/prompt"
+)
+
+// PromptRepository defines the contract for prompt persistence.
+type PromptRepository interface {
+	List(ctx context.Context, limit, offset int) ([]*prompt.Prompt, error)
+	Count(ctx context.Context) (int, error)
+	GetByID(ctx context.Context, id string) (*prompt.Prompt, error)
+	Create(ctx context.Context, p *prompt.Prompt) error
+	Update(ctx context.Context, p *prompt.Prompt) error
+	Delete(ctx context.Context, id string) error
+}

--- a/internal/services/server.go
+++ b/internal/services/server.go
@@ -17,6 +17,7 @@ import (
 	httpprovidertester "github.com/DEEJ4Y/genkitkraft/internal/adapters/http_provider_tester"
 	memorysession "github.com/DEEJ4Y/genkitkraft/internal/adapters/memory_session"
 	sqlitedb "github.com/DEEJ4Y/genkitkraft/internal/adapters/sqlite_db"
+	sqliteprompt "github.com/DEEJ4Y/genkitkraft/internal/adapters/sqlite_prompt"
 	sqliteprovider "github.com/DEEJ4Y/genkitkraft/internal/adapters/sqlite_provider"
 	"github.com/DEEJ4Y/genkitkraft/internal/api/gen"
 	"github.com/DEEJ4Y/genkitkraft/internal/app"
@@ -36,6 +37,7 @@ type Server struct {
 	cfg          config.Config
 	authApp      *app.AuthApp
 	providerApp  *app.ProviderApp
+	promptApp    *app.PromptApp
 	sessionStore session.Store
 	db           *sql.DB
 	done         chan struct{}
@@ -134,10 +136,36 @@ func NewServer(cfg config.Config) (*Server, error) {
 		},
 	}
 
+	// Create prompt adapters
+	promptRepo := sqliteprompt.NewPromptRepository(db)
+
+	// Create prompt commands
+	createPromptCmd := commands.NewCreatePromptCommand(promptRepo)
+	updatePromptCmd := commands.NewUpdatePromptCommand(promptRepo)
+	deletePromptCmd := commands.NewDeletePromptCommand(promptRepo)
+
+	// Create prompt queries
+	listPromptsQuery := queries.NewListPromptsQuery(promptRepo)
+	getPromptQuery := queries.NewGetPromptQuery(promptRepo)
+
+	// Build prompt application
+	promptApp := &app.PromptApp{
+		Commands: app.PromptCommands{
+			CreatePrompt: decorators.ApplyLogging(createPromptCmd, "CreatePrompt", logger),
+			UpdatePrompt: decorators.ApplyLogging(updatePromptCmd, "UpdatePrompt", logger),
+			DeletePrompt: decorators.ApplyLoggingExecutor(deletePromptCmd, "DeletePrompt", logger),
+		},
+		Queries: app.PromptQueries{
+			ListPrompts: decorators.ApplyLogging(listPromptsQuery, "ListPrompts", logger),
+			GetPrompt:   decorators.ApplyLogging(getPromptQuery, "GetPrompt", logger),
+		},
+	}
+
 	return &Server{
 		cfg:          cfg,
 		authApp:      authApp,
 		providerApp:  providerApp,
+		promptApp:    promptApp,
 		sessionStore: sessionStore,
 		db:           db,
 		done:         make(chan struct{}),
@@ -151,7 +179,7 @@ func (s *Server) Start() error {
 	mux := http.NewServeMux()
 
 	// Register all API routes via generated handler
-	apiHandler := httphandler.NewHandler(s.authApp, s.providerApp)
+	apiHandler := httphandler.NewHandler(s.authApp, s.providerApp, s.promptApp)
 	gen.HandlerFromMux(apiHandler, mux)
 
 	// SPA fallback: serve embedded UI or fallback to index.html

--- a/spec/main.tsp
+++ b/spec/main.tsp
@@ -2,6 +2,7 @@ import "@typespec/http";
 import "./routes/health.tsp";
 import "./routes/auth.tsp";
 import "./routes/providers.tsp";
+import "./routes/prompts.tsp";
 
 using TypeSpec.Http;
 

--- a/spec/models/prompt.tsp
+++ b/spec/models/prompt.tsp
@@ -1,0 +1,52 @@
+namespace Api.Models;
+
+/** A prompt (system instruction) for an agent. */
+model PromptResponse {
+  /** Unique prompt ID. */
+  id: string;
+
+  /** Display name for this prompt. */
+  name: string;
+
+  /** Prompt content in markdown format. */
+  content: string;
+
+  /** When this prompt was created. */
+  createdAt: utcDateTime;
+
+  /** When this prompt was last updated. */
+  updatedAt: utcDateTime;
+}
+
+/** Request to create a new prompt. */
+model CreatePromptRequest {
+  /** Display name for this prompt. */
+  name: string;
+
+  /** Prompt content in markdown format. */
+  content: string;
+}
+
+/** Request to update an existing prompt. */
+model UpdatePromptRequest {
+  /** Updated display name. */
+  name?: string;
+
+  /** Updated prompt content in markdown format. */
+  content?: string;
+}
+
+/** Paginated list of prompts. */
+model PromptListResponse {
+  /** Array of prompts. */
+  prompts: PromptResponse[];
+
+  /** Total number of prompts. */
+  total: int32;
+
+  /** Number of prompts per page. */
+  limit: int32;
+
+  /** Number of prompts skipped. */
+  offset: int32;
+}

--- a/spec/routes/prompts.tsp
+++ b/spec/routes/prompts.tsp
@@ -1,0 +1,61 @@
+import "@typespec/http";
+import "@typespec/openapi";
+import "../models/prompt.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+using Api.Models;
+
+namespace Api.Routes;
+
+@tag("Prompts")
+namespace Prompts {
+  /** List all prompts with pagination. */
+  @get
+  @route("/api/v1/prompts")
+  @summary("List prompts")
+  @operationId("listPrompts")
+  op listPrompts(@query limit?: int32 = 20, @query offset?: int32 = 0): PromptListResponse;
+
+  /** Create a new prompt. */
+  @post
+  @route("/api/v1/prompts")
+  @summary("Create prompt")
+  @operationId("createPrompt")
+  op createPrompt(@body body: CreatePromptRequest): {
+    @statusCode statusCode: 201;
+    @body body: PromptResponse;
+  };
+
+  /** Get a single prompt by ID. */
+  @get
+  @route("/api/v1/prompts/{id}")
+  @summary("Get prompt")
+  @operationId("getPrompt")
+  op getPrompt(@path id: string): PromptResponse | {
+    @statusCode statusCode: 404;
+    @body body: ErrorResponse;
+  };
+
+  /** Update an existing prompt. */
+  @put
+  @route("/api/v1/prompts/{id}")
+  @summary("Update prompt")
+  @operationId("updatePrompt")
+  op updatePrompt(@path id: string, @body body: UpdatePromptRequest): PromptResponse | {
+    @statusCode statusCode: 404;
+    @body body: ErrorResponse;
+  };
+
+  /** Delete a prompt. */
+  @delete
+  @route("/api/v1/prompts/{id}")
+  @summary("Delete prompt")
+  @operationId("deletePrompt")
+  op deletePrompt(@path id: string): {
+    @statusCode statusCode: 204;
+  } | {
+    @statusCode statusCode: 404;
+    @body body: ErrorResponse;
+  };
+}

--- a/spec/tsp-output/schema/openapi.yaml
+++ b/spec/tsp-output/schema/openapi.yaml
@@ -6,6 +6,7 @@ tags:
   - name: Health
   - name: Auth
   - name: Settings
+  - name: Prompts
 paths:
   /api/auth/login:
     post:
@@ -97,6 +98,135 @@ paths:
                 $ref: '#/components/schemas/Models.AuthStatusResponse'
       tags:
         - Auth
+  /api/v1/prompts:
+    get:
+      operationId: listPrompts
+      summary: List prompts
+      description: List all prompts with pagination.
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 20
+          explode: false
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Models.PromptListResponse'
+      tags:
+        - Prompts
+    post:
+      operationId: createPrompt
+      summary: Create prompt
+      description: Create a new prompt.
+      parameters: []
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Models.PromptResponse'
+      tags:
+        - Prompts
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Models.CreatePromptRequest'
+  /api/v1/prompts/{id}:
+    get:
+      operationId: getPrompt
+      summary: Get prompt
+      description: Get a single prompt by ID.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Models.PromptResponse'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Models.ErrorResponse'
+      tags:
+        - Prompts
+    put:
+      operationId: updatePrompt
+      summary: Update prompt
+      description: Update an existing prompt.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Models.PromptResponse'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Models.ErrorResponse'
+      tags:
+        - Prompts
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Models.UpdatePromptRequest'
+    delete:
+      operationId: deletePrompt
+      summary: Delete prompt
+      description: Delete a prompt.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Models.ErrorResponse'
+      tags:
+        - Prompts
   /api/v1/provider-types:
     get:
       operationId: listProviderTypes
@@ -372,6 +502,19 @@ components:
           type: boolean
           description: Whether the field contains sensitive data.
       description: Describes a config field for a provider type.
+    Models.CreatePromptRequest:
+      type: object
+      required:
+        - name
+        - content
+      properties:
+        name:
+          type: string
+          description: Display name for this prompt.
+        content:
+          type: string
+          description: Prompt content in markdown format.
+      description: Request to create a new prompt.
     Models.CreateProviderRequest:
       type: object
       required:
@@ -487,6 +630,59 @@ components:
     Models.OpenAIProviderConfig:
       type: object
       description: OpenAI provider config (no extra fields needed).
+    Models.PromptListResponse:
+      type: object
+      required:
+        - prompts
+        - total
+        - limit
+        - offset
+      properties:
+        prompts:
+          type: array
+          items:
+            $ref: '#/components/schemas/Models.PromptResponse'
+          description: Array of prompts.
+        total:
+          type: integer
+          format: int32
+          description: Total number of prompts.
+        limit:
+          type: integer
+          format: int32
+          description: Number of prompts per page.
+        offset:
+          type: integer
+          format: int32
+          description: Number of prompts skipped.
+      description: Paginated list of prompts.
+    Models.PromptResponse:
+      type: object
+      required:
+        - id
+        - name
+        - content
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          description: Unique prompt ID.
+        name:
+          type: string
+          description: Display name for this prompt.
+        content:
+          type: string
+          description: Prompt content in markdown format.
+        createdAt:
+          type: string
+          format: date-time
+          description: When this prompt was created.
+        updatedAt:
+          type: string
+          format: date-time
+          description: When this prompt was last updated.
+      description: A prompt (system instruction) for an agent.
     Models.ProviderListResponse:
       type: object
       required:
@@ -622,6 +818,16 @@ components:
           type: string
           description: Human-readable result message.
       description: Result of testing provider connectivity.
+    Models.UpdatePromptRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Updated display name.
+        content:
+          type: string
+          description: Updated prompt content in markdown format.
+      description: Request to update an existing prompt.
     Models.UpdateProviderRequest:
       type: object
       properties:

--- a/ui/components/AppLayout.tsx
+++ b/ui/components/AppLayout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 import { AppShell, NavLink, Title, Text, Button } from '@mantine/core'
-import { IconHome2, IconSettings, IconLogout } from '@tabler/icons-react'
+import { IconHome2, IconFileText, IconSettings, IconLogout } from '@tabler/icons-react'
 import { useRouter } from 'next/router'
 import { useAuth } from '../lib/auth'
 
@@ -23,6 +23,12 @@ export function AppLayout({ children }: { children: ReactNode }) {
             leftSection={<IconHome2 size={18} />}
             active={router.pathname === '/'}
             onClick={() => router.push('/')}
+          />
+          <NavLink
+            label="Prompts"
+            leftSection={<IconFileText size={18} />}
+            active={router.pathname === '/prompts'}
+            onClick={() => router.push('/prompts')}
           />
           <NavLink
             label="Settings"

--- a/ui/components/PromptCard.tsx
+++ b/ui/components/PromptCard.tsx
@@ -1,0 +1,59 @@
+import { Card, Text, Group, ActionIcon, Tooltip } from '@mantine/core'
+import { IconEdit, IconTrash } from '@tabler/icons-react'
+import type { components } from '../lib/api/schema'
+
+type PromptResponse = components['schemas']['Models.PromptResponse']
+
+interface PromptCardProps {
+  prompt: PromptResponse
+  onEdit: () => void
+  onDelete: () => void
+}
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text
+  return text.slice(0, maxLength) + '...'
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+export function PromptCard({ prompt, onEdit, onDelete }: PromptCardProps) {
+  return (
+    <Card shadow="xs" padding="md" radius="sm" withBorder>
+      <Group justify="space-between" align="flex-start" wrap="nowrap">
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <Text fw={600} size="md">
+            {prompt.name}
+          </Text>
+          {prompt.content && (
+            <Text size="sm" c="dimmed" mt={4} lineClamp={2}>
+              {truncate(prompt.content, 150)}
+            </Text>
+          )}
+          <Text size="xs" c="dimmed" mt={8}>
+            Updated {formatDate(prompt.updatedAt as unknown as string)}
+          </Text>
+        </div>
+
+        <Group gap="xs" wrap="nowrap">
+          <Tooltip label="Edit">
+            <ActionIcon variant="subtle" onClick={onEdit}>
+              <IconEdit size={18} />
+            </ActionIcon>
+          </Tooltip>
+          <Tooltip label="Delete">
+            <ActionIcon variant="subtle" color="red" onClick={onDelete}>
+              <IconTrash size={18} />
+            </ActionIcon>
+          </Tooltip>
+        </Group>
+      </Group>
+    </Card>
+  )
+}

--- a/ui/components/PromptEditor.tsx
+++ b/ui/components/PromptEditor.tsx
@@ -1,0 +1,75 @@
+import { RichTextEditor } from '@mantine/tiptap'
+import { useEditor, type Editor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import Link from '@tiptap/extension-link'
+import Placeholder from '@tiptap/extension-placeholder'
+import { Markdown } from 'tiptap-markdown'
+import { useEffect } from 'react'
+
+interface PromptEditorProps {
+  content: string
+  onChange: (markdown: string) => void
+  placeholder?: string
+}
+
+function getMarkdown(editor: Editor): string {
+  return (editor.storage as any).markdown.getMarkdown()
+}
+
+export function PromptEditor({ content, onChange, placeholder }: PromptEditorProps) {
+  const editor = useEditor({
+    extensions: [
+      StarterKit,
+      Link.configure({ openOnClick: false }),
+      Placeholder.configure({ placeholder: placeholder || 'Write your system instructions here...' }),
+      Markdown,
+    ],
+    content,
+    onUpdate: ({ editor }) => {
+      onChange(getMarkdown(editor))
+    },
+  })
+
+  useEffect(() => {
+    if (editor && content !== getMarkdown(editor)) {
+      editor.commands.setContent(content)
+    }
+  }, [content, editor])
+
+  return (
+    <RichTextEditor editor={editor}>
+      <RichTextEditor.Toolbar sticky stickyOffset={0}>
+        <RichTextEditor.ControlsGroup>
+          <RichTextEditor.Bold />
+          <RichTextEditor.Italic />
+          <RichTextEditor.Strikethrough />
+          <RichTextEditor.Code />
+        </RichTextEditor.ControlsGroup>
+
+        <RichTextEditor.ControlsGroup>
+          <RichTextEditor.H1 />
+          <RichTextEditor.H2 />
+          <RichTextEditor.H3 />
+        </RichTextEditor.ControlsGroup>
+
+        <RichTextEditor.ControlsGroup>
+          <RichTextEditor.BulletList />
+          <RichTextEditor.OrderedList />
+        </RichTextEditor.ControlsGroup>
+
+        <RichTextEditor.ControlsGroup>
+          <RichTextEditor.Blockquote />
+          <RichTextEditor.CodeBlock />
+          <RichTextEditor.Hr />
+        </RichTextEditor.ControlsGroup>
+
+        <RichTextEditor.ControlsGroup>
+          <RichTextEditor.Link />
+          <RichTextEditor.Unlink />
+        </RichTextEditor.ControlsGroup>
+      </RichTextEditor.Toolbar>
+
+      <RichTextEditor.Content />
+    </RichTextEditor>
+  )
+}

--- a/ui/components/PromptForm.tsx
+++ b/ui/components/PromptForm.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react'
+import { TextInput, Button, Group, Stack, Alert, Text } from '@mantine/core'
+import { IconArrowLeft } from '@tabler/icons-react'
+import { fetchClient } from '../lib/api/client'
+import { PromptEditor } from './PromptEditor'
+import type { components } from '../lib/api/schema'
+
+type PromptResponse = components['schemas']['Models.PromptResponse']
+
+interface PromptFormProps {
+  prompt?: PromptResponse
+  onSaved: () => void
+  onCancel: () => void
+}
+
+export function PromptForm({ prompt, onSaved, onCancel }: PromptFormProps) {
+  const isEdit = !!prompt
+  const [name, setName] = useState(prompt?.name ?? '')
+  const [content, setContent] = useState(prompt?.content ?? '')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  async function handleSubmit() {
+    if (!name.trim()) {
+      setError('Name is required')
+      return
+    }
+
+    setSaving(true)
+    setError('')
+
+    try {
+      if (isEdit) {
+        const { error: err } = await fetchClient.PUT('/api/v1/prompts/{id}', {
+          params: { path: { id: prompt.id } },
+          body: { name: name.trim(), content } as any,
+        })
+        if (err) throw new Error((err as any).error)
+      } else {
+        const { error: err } = await fetchClient.POST('/api/v1/prompts', {
+          body: { name: name.trim(), content } as any,
+        })
+        if (err) throw new Error((err as any).error)
+      }
+      onSaved()
+    } catch (err: any) {
+      setError(err.message || 'Failed to save prompt')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Stack>
+      <Button
+        variant="subtle"
+        leftSection={<IconArrowLeft size={16} />}
+        onClick={onCancel}
+        size="sm"
+        w="fit-content"
+      >
+        Back to Prompts
+      </Button>
+
+      <Text size="xl" fw={600}>
+        {isEdit ? 'Edit Prompt' : 'New Prompt'}
+      </Text>
+
+      {error && (
+        <Alert color="red" variant="light">
+          {error}
+        </Alert>
+      )}
+
+      <TextInput
+        label="Name"
+        placeholder="e.g. Code Review Assistant"
+        value={name}
+        onChange={(e) => setName(e.currentTarget.value)}
+        required
+      />
+
+      <div>
+        <Text size="sm" fw={500} mb={4}>
+          Content
+        </Text>
+        <PromptEditor content={content} onChange={setContent} />
+      </div>
+
+      <Group>
+        <Button onClick={handleSubmit} loading={saving}>
+          {isEdit ? 'Save Changes' : 'Create Prompt'}
+        </Button>
+        <Button variant="default" onClick={onCancel}>
+          Cancel
+        </Button>
+      </Group>
+    </Stack>
+  )
+}

--- a/ui/lib/api/schema.d.ts
+++ b/ui/lib/api/schema.d.ts
@@ -84,6 +84,58 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/prompts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List prompts
+         * @description List all prompts with pagination.
+         */
+        get: operations["listPrompts"];
+        put?: never;
+        /**
+         * Create prompt
+         * @description Create a new prompt.
+         */
+        post: operations["createPrompt"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/prompts/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get prompt
+         * @description Get a single prompt by ID.
+         */
+        get: operations["getPrompt"];
+        /**
+         * Update prompt
+         * @description Update an existing prompt.
+         */
+        put: operations["updatePrompt"];
+        post?: never;
+        /**
+         * Delete prompt
+         * @description Delete a prompt.
+         */
+        delete: operations["deletePrompt"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/provider-types": {
         parameters: {
             query?: never;
@@ -260,6 +312,13 @@ export interface components {
             /** @description Whether the field contains sensitive data. */
             sensitive?: boolean;
         };
+        /** @description Request to create a new prompt. */
+        "Models.CreatePromptRequest": {
+            /** @description Display name for this prompt. */
+            name: string;
+            /** @description Prompt content in markdown format. */
+            content: string;
+        };
         /** @description Request to create a new provider configuration. */
         "Models.CreateProviderRequest": {
             /** @description Display name for this provider. */
@@ -328,6 +387,45 @@ export interface components {
         };
         /** @description OpenAI provider config (no extra fields needed). */
         "Models.OpenAIProviderConfig": Record<string, never>;
+        /** @description Paginated list of prompts. */
+        "Models.PromptListResponse": {
+            /** @description Array of prompts. */
+            prompts: components["schemas"]["Models.PromptResponse"][];
+            /**
+             * Format: int32
+             * @description Total number of prompts.
+             */
+            total: number;
+            /**
+             * Format: int32
+             * @description Number of prompts per page.
+             */
+            limit: number;
+            /**
+             * Format: int32
+             * @description Number of prompts skipped.
+             */
+            offset: number;
+        };
+        /** @description A prompt (system instruction) for an agent. */
+        "Models.PromptResponse": {
+            /** @description Unique prompt ID. */
+            id: string;
+            /** @description Display name for this prompt. */
+            name: string;
+            /** @description Prompt content in markdown format. */
+            content: string;
+            /**
+             * Format: date-time
+             * @description When this prompt was created.
+             */
+            createdAt: string;
+            /**
+             * Format: date-time
+             * @description When this prompt was last updated.
+             */
+            updatedAt: string;
+        };
         /** @description List of configured providers. */
         "Models.ProviderListResponse": {
             /** @description Array of provider configurations. */
@@ -399,6 +497,13 @@ export interface components {
             success: boolean;
             /** @description Human-readable result message. */
             message: string;
+        };
+        /** @description Request to update an existing prompt. */
+        "Models.UpdatePromptRequest": {
+            /** @description Updated display name. */
+            name?: string;
+            /** @description Updated prompt content in markdown format. */
+            content?: string;
         };
         /** @description Request to update an existing provider configuration. */
         "Models.UpdateProviderRequest": {
@@ -549,6 +654,148 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Models.AuthStatusResponse"];
+                };
+            };
+        };
+    };
+    listPrompts: {
+        parameters: {
+            query?: {
+                limit?: number;
+                offset?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Models.PromptListResponse"];
+                };
+            };
+        };
+    };
+    createPrompt: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Models.CreatePromptRequest"];
+            };
+        };
+        responses: {
+            /** @description The request has succeeded and a new resource has been created as a result. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Models.PromptResponse"];
+                };
+            };
+        };
+    };
+    getPrompt: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Models.PromptResponse"];
+                };
+            };
+            /** @description The server cannot find the requested resource. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Models.ErrorResponse"];
+                };
+            };
+        };
+    };
+    updatePrompt: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Models.UpdatePromptRequest"];
+            };
+        };
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Models.PromptResponse"];
+                };
+            };
+            /** @description The server cannot find the requested resource. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Models.ErrorResponse"];
+                };
+            };
+        };
+    };
+    deletePrompt: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description There is no content to send for this request, but the headers may be useful. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description The server cannot find the requested resource. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Models.ErrorResponse"];
                 };
             };
         };

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,13 +10,20 @@
       "dependencies": {
         "@mantine/core": "^8.3.18",
         "@mantine/hooks": "^8.3.18",
+        "@mantine/tiptap": "^8.3.18",
         "@tabler/icons-react": "^3.40.0",
         "@tanstack/react-query": "^5.62.0",
+        "@tiptap/extension-link": "^3.20.4",
+        "@tiptap/extension-placeholder": "^3.20.4",
+        "@tiptap/pm": "^3.20.4",
+        "@tiptap/react": "^3.20.4",
+        "@tiptap/starter-kit": "^3.20.4",
         "next": "^14.2.0",
         "openapi-fetch": "^0.17.0",
         "openapi-react-query": "^0.5.4",
         "react": "^18.3.0",
-        "react-dom": "^18.3.0"
+        "react-dom": "^18.3.0",
+        "tiptap-markdown": "^0.9.0"
       },
       "devDependencies": {
         "@types/node": "^20.14.0",
@@ -142,6 +149,20 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.x || ^19.x"
+      }
+    },
+    "node_modules/@mantine/tiptap": {
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/tiptap/-/tiptap-8.3.18.tgz",
+      "integrity": "sha512-CrV5E0ELJmegyq+iF4g6PkEeC95wGY9QjWjb+JS1KE4UbxJONxRxGhpjQMp1t/Ir2aFVu9Gbf/fQ0qSnD6Lmqw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@mantine/core": "8.3.18",
+        "@mantine/hooks": "8.3.18",
+        "@tiptap/extension-link": ">=2.1.12",
+        "@tiptap/react": ">=2.1.12",
+        "react": "^18.x || ^19.x",
+        "react-dom": "^18.x || ^19.x"
       }
     },
     "node_modules/@next/env": {
@@ -340,6 +361,12 @@
         "npm": ">=9.5.0"
       }
     },
+    "node_modules/@remirror/core-constants": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
+      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
+      "license": "MIT"
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -408,6 +435,475 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@tiptap/core": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.20.4.tgz",
+      "integrity": "sha512-3i/DG89TFY/b34T5P+j35UcjYuB5d3+9K8u6qID+iUqNPiza015HPIZLuPfE5elNwVdV3EXIoPo0LLeBLgXXAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.20.4.tgz",
+      "integrity": "sha512-9sskyyhYj2oKat//lyZVXCp9YrPt4oJAZnGHYWXS0xlskjsLElrfKKlM4vpbhGss3VrhQRoEGqWLnIaJYPF1zw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.20.4.tgz",
+      "integrity": "sha512-Md7/mNAeJCY+VLJc8JRGI+8XkVPKiOGB1NgqQPdh3aYtxXQDChQOZoJEQl6TuudDxZ85bLZB67NjZlx3jo8/0g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.20.4.tgz",
+      "integrity": "sha512-EXywPlI8wjPcAb8ozymgVhjtMjFrnhtoyNTy8ZcObdpUi5CdO9j892Y7aPbKe5hLhlDpvJk7rMfir4FFKEmfng==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4",
+        "@tiptap/pm": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.20.4.tgz",
+      "integrity": "sha512-1RTGrur1EKoxfnLZ3M6xeNj8GITAz74jH2DHGcjLsd2Xr7Q7BozGaIq6GkkvKguMwbI1zCOxTHFCpUETXAIQQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.20.4.tgz",
+      "integrity": "sha512-7j8Hi964bH1SZ9oLdZC1fkqWz27mliSDV7M8lmL/M14+Qw42D/VOAKS4Aw9OCFtHMlTsjLR6qsoVxL8Lpkt6NA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.20.4.tgz",
+      "integrity": "sha512-Zlw3FrXTy01+o1yISeX/LC+iJeHA+ym602bMXGmtA6lyl7QSOSO7WExweJ6xeJGhbCjldwT5al6fkRAs8iGJZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4",
+        "@tiptap/pm": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.20.4.tgz",
+      "integrity": "sha512-zF1CIFVLt8MfSpWWnPwtGyxPOsT0xYM2qJKcXf2yZcTG37wDKmUi6heG53vGigIavbQlLaAFvs+1mNdOu2x/0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.20.4.tgz",
+      "integrity": "sha512-TgMwvZ8myXYdmd6bUV7qkpZXv7ZUiSmX/8eo+iPEzYo2CnDLAGvDKgC50nfq/g87SDvfBgPuAiBfFvsMQQWaTw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.20.4.tgz",
+      "integrity": "sha512-AaPTFhoO8DBIElJyd/RTVJjkctvJuL+GHURX0npbtTxXq5HXbebVwf2ARNR7jMd/GThsmBaNJiGxZg4A2oeDqQ==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "^3.20.4",
+        "@tiptap/pm": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.20.4.tgz",
+      "integrity": "sha512-JJ6f1iQ1e0s4kISgq55U3UYGwWV/N9f0PYMtB6e3L+SBQjXnywaLK0g6vfN6IvTCC2vdIuqeSOX8VlSO97sJLw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.20.4.tgz",
+      "integrity": "sha512-gJbq58d8zB1gzyqVEopowej5CpW4/Fpg6oGJvlZxaCukqd0gJRWGC89K+jE62YA1Td4sfcKrekKvN7jm2y/ZUg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.20.4.tgz",
+      "integrity": "sha512-xsnkmTGggJc5P2iCwS1lv8KFG31xC/GNPJKoi/3UH67j/lKDhA3AdtshsLeyv2FKtTtYDb8oV0IqzHB1MM6a7w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.20.4.tgz",
+      "integrity": "sha512-y6joCi49haAA0bo3EGUY+dWUMHH1GPUc84hxrBY/0pMs+Bn+kQ1+DQJErZDTWGJrlHPWU/yekBZT72SNdp0DNA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4",
+        "@tiptap/pm": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.20.4.tgz",
+      "integrity": "sha512-4ZqiWr7cmqPFux8tj1ZLiYytyWf343IvQemNX6AvVWvscrJcrfj3YX4Le2BA0RW3A3M6RpLQXXozuF8vxYFDeQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.20.4.tgz",
+      "integrity": "sha512-JNDSkWrVdb8NSvbQXwHWvK5tCMbTWwOHFOweknQZ1JPK4dei9FJVofYQaHyW4bJBdcCjds3NZSnXE8DM9iAWmg==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4",
+        "@tiptap/pm": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.20.4.tgz",
+      "integrity": "sha512-X+5plTKhOioNcQ4KsAFJJSb/3+zR8Xhdpow4HzXtoV1KcbdDey1fhZdpsfkbrzCL0s6/wAgwZuAchCK7HujurQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4",
+        "@tiptap/pm": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.20.4.tgz",
+      "integrity": "sha512-QoTc5RACXaZF+vIIBBxjGO7D0oWFUDgBKJCpvUZ0CoGGKosnfe4a9I5THFyLj4201cf0oUqgf1oZhTqETGxlVw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.20.4.tgz",
+      "integrity": "sha512-RIqXM649+8IP7p/KVfaGlJiwjCylm1m6OPlaoM3K8O7oEOGRQzNeexexECCD2jsXRxew4E+vBNMD2orXqJmu8A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.20.4.tgz",
+      "integrity": "sha512-3budNL8BgBon3TcXZ4hjT0YpFvx1Ka3uSIECKDxHgES+OQcR+6cagxSb60gFEccf3Dr0PIwcVTY6g14lC1qKRQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.20.4.tgz",
+      "integrity": "sha512-lm6fOScWuZAF/Sfp97igUwFd3L1QHIVLAWP5NVdh0DTLrEIt4rMBmsww+yOpMQRhvz2uTgMbMXynrimhzi/QVw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-placeholder": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.20.4.tgz",
+      "integrity": "sha512-GB0KWtqm83YHG8cnqBLijvUBm+xvLfQHDfFRRH2fb3EzH3eIsM9jKRC31ADT27RSV1zVpHMFGcP3/pWpdrN1Lw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.20.4.tgz",
+      "integrity": "sha512-It1Px9uDGTsVqyyg6cy7DigLoenljpQwqdI0jssM7QclZrHnsrye9fZxBBiiuCzzV1305MxKgHvratkHwqmVNA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.20.4.tgz",
+      "integrity": "sha512-jchJcBZixDEO2J66Zx5dchsI2mA6IYsROqF8P1poxL4ienH7RVQRCTsBNnSfIeOtREKKWeOU/tEs5fcpvvGwIQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.20.4.tgz",
+      "integrity": "sha512-0OjMc3FDujX16G+jhvqcY/mLot8SrNtDu8ggUwNLAfiI/QIvMVgk7giFD71DATC/4Nb8i/iwAEegTD8MxBIXCg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.20.4.tgz",
+      "integrity": "sha512-8p6hVT65DjuQjtEdlH6ewX9SOJHlVQAOee3sWIJQmeJNRnZNvqPIBLleebUqDiljNTpxBv6s6QWkSTKgf3btwg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4",
+        "@tiptap/pm": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.20.4.tgz",
+      "integrity": "sha512-rCHYSBToilBEuI6PtjziHDdRkABH/XqwJ7dG4Amn/SD3yGiZKYCiEApQlTUS2zZeo8DsLeuqqqB4vEOeD4OEPg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-collab": "^1.3.1",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-markdown": "^1.13.1",
+        "prosemirror-menu": "^1.2.4",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-basic": "^1.2.3",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-trailing-node": "^3.0.0",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/react": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.20.4.tgz",
+      "integrity": "sha512-1B8iWsHWwb5TeyVaUs8BRPzwWo4PsLQcl03urHaz0zTJ8DauopqvxzV3+lem1OkzRHn7wnrapDvwmIGoROCaQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-equals": "^5.3.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.20.4",
+        "@tiptap/extension-floating-menu": "^3.20.4"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4",
+        "@tiptap/pm": "^3.20.4",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.20.4.tgz",
+      "integrity": "sha512-WcyK6hsTl8eBsQhQ+d9Sq8fYZKOYdL+D45MyH3hz583elXqJlW3h3JPFYb0o87gddGxn8Mm57OA/gA1zEdeDMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.20.4",
+        "@tiptap/extension-blockquote": "^3.20.4",
+        "@tiptap/extension-bold": "^3.20.4",
+        "@tiptap/extension-bullet-list": "^3.20.4",
+        "@tiptap/extension-code": "^3.20.4",
+        "@tiptap/extension-code-block": "^3.20.4",
+        "@tiptap/extension-document": "^3.20.4",
+        "@tiptap/extension-dropcursor": "^3.20.4",
+        "@tiptap/extension-gapcursor": "^3.20.4",
+        "@tiptap/extension-hard-break": "^3.20.4",
+        "@tiptap/extension-heading": "^3.20.4",
+        "@tiptap/extension-horizontal-rule": "^3.20.4",
+        "@tiptap/extension-italic": "^3.20.4",
+        "@tiptap/extension-link": "^3.20.4",
+        "@tiptap/extension-list": "^3.20.4",
+        "@tiptap/extension-list-item": "^3.20.4",
+        "@tiptap/extension-list-keymap": "^3.20.4",
+        "@tiptap/extension-ordered-list": "^3.20.4",
+        "@tiptap/extension-paragraph": "^3.20.4",
+        "@tiptap/extension-strike": "^3.20.4",
+        "@tiptap/extension-text": "^3.20.4",
+        "@tiptap/extension-underline": "^3.20.4",
+        "@tiptap/extensions": "^3.20.4",
+        "@tiptap/pm": "^3.20.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
@@ -422,14 +918,12 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -440,11 +934,16 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
@@ -470,7 +969,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/balanced-match": {
@@ -560,6 +1058,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -577,7 +1081,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -604,12 +1107,45 @@
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -707,6 +1243,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -718,6 +1269,35 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-task-lists": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
+      "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==",
+      "license": "ISC"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "5.1.9",
@@ -882,6 +1462,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.1.0.tgz",
       "integrity": "sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==",
+      "license": "MIT"
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
     },
     "node_modules/parse-json": {
@@ -1086,6 +1672,210 @@
         "postcss": "^8.2.1"
       }
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.0.tgz",
+      "integrity": "sha512-LvqH2v7Q2SF6yxatuPP2e8vSUKS/L+xAU7dPDC4RMyHMhZoGDfBC74mYuyYF4gLqOEG758wajtyhNnsTkuhvng==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-collab": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
+      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
+      "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-menu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.0.tgz",
+      "integrity": "sha512-TImyPXCHPcDsSka2/lwJ6WjTASr4re/qWq1yoTTuLOqfXucwF6VcRa2LWCkM/EyTD1UO3CUwiH8qURJoWJRxwg==",
+      "license": "MIT",
+      "dependencies": {
+        "crelt": "^1.0.0",
+        "prosemirror-commands": "^1.0.0",
+        "prosemirror-history": "^1.0.0",
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-basic": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
+      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-trailing-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
+      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remirror/core-constants": "3.0.0",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.11.0.tgz",
+      "integrity": "sha512-4I7Ce4KpygXb9bkiPS3hTEk4dSHorfRw8uI0pE8IhxlK2GXsqv5tIA7JUSxtSu7u8APVOTtbUBxTmnHIxVkIJw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.7",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.7.tgz",
+      "integrity": "sha512-jUwKNCEIGiqdvhlS91/2QAg21e4dfU5bH2iwmSDQeosXJgKF7smG0YSplOWK0cjSNgIqXe7VXqo7EIfUFJdt3w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1217,6 +2007,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -1325,6 +2121,46 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tiptap-markdown": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/tiptap-markdown/-/tiptap-markdown-0.9.0.tgz",
+      "integrity": "sha512-dKLQ9iiuGNgrlGVjrNauF/UBzWu4LYOx5pkD0jNkmQt/GOwfCJsBuzZTsf1jZ204ANHOm572mZ9PYvGh1S7tpQ==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "dependencies": {
+        "@types/markdown-it": "^13.0.7",
+        "markdown-it": "^14.1.0",
+        "markdown-it-task-lists": "^2.1.1",
+        "prosemirror-markdown": "^1.11.1"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.0.1"
+      }
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/linkify-it": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
+      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
+      "license": "MIT"
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/markdown-it": {
+      "version": "13.0.9",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.9.tgz",
+      "integrity": "sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^3",
+        "@types/mdurl": "^1"
+      }
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/mdurl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
+      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1356,6 +2192,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -1459,11 +2301,26 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
     "node_modules/yaml-ast-parser": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,13 +11,20 @@
   "dependencies": {
     "@mantine/core": "^8.3.18",
     "@mantine/hooks": "^8.3.18",
+    "@mantine/tiptap": "^8.3.18",
     "@tabler/icons-react": "^3.40.0",
     "@tanstack/react-query": "^5.62.0",
+    "@tiptap/extension-link": "^3.20.4",
+    "@tiptap/extension-placeholder": "^3.20.4",
+    "@tiptap/pm": "^3.20.4",
+    "@tiptap/react": "^3.20.4",
+    "@tiptap/starter-kit": "^3.20.4",
     "next": "^14.2.0",
     "openapi-fetch": "^0.17.0",
     "openapi-react-query": "^0.5.4",
     "react": "^18.3.0",
-    "react-dom": "^18.3.0"
+    "react-dom": "^18.3.0",
+    "tiptap-markdown": "^0.9.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",

--- a/ui/pages/_app.tsx
+++ b/ui/pages/_app.tsx
@@ -5,6 +5,7 @@ import { queryClient } from '../lib/queryClient'
 import { AuthProvider, AuthGate } from '../lib/auth'
 import { AppLayout } from '../components/AppLayout'
 import '@mantine/core/styles.css'
+import '@mantine/tiptap/styles.css'
 
 export default function App({ Component, pageProps }: AppProps) {
   return (

--- a/ui/pages/prompts.tsx
+++ b/ui/pages/prompts.tsx
@@ -1,0 +1,155 @@
+import { useState } from 'react'
+import {
+  Title,
+  Text,
+  Stack,
+  Group,
+  Button,
+  Loader,
+  Alert,
+  Center,
+  Pagination,
+} from '@mantine/core'
+import { IconPlus } from '@tabler/icons-react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { fetchClient } from '../lib/api/client'
+import { PromptCard } from '../components/PromptCard'
+import { PromptForm } from '../components/PromptForm'
+import type { components } from '../lib/api/schema'
+
+type PromptResponse = components['schemas']['Models.PromptResponse']
+
+type View = { mode: 'list' } | { mode: 'create' } | { mode: 'edit'; promptId: string }
+
+const PAGE_SIZE = 20
+
+export default function PromptsPage() {
+  const queryClient = useQueryClient()
+  const [view, setView] = useState<View>({ mode: 'list' })
+  const [page, setPage] = useState(1)
+
+  const offset = (page - 1) * PAGE_SIZE
+
+  const promptsQuery = useQuery({
+    queryKey: ['get', '/api/v1/prompts', { limit: PAGE_SIZE, offset }],
+    queryFn: async () => {
+      const { data, error } = await fetchClient.GET('/api/v1/prompts', {
+        params: { query: { limit: PAGE_SIZE, offset } },
+      })
+      if (error) throw new Error('Failed to fetch prompts')
+      return data
+    },
+  })
+
+  const editingPromptId = view.mode === 'edit' ? view.promptId : null
+
+  const editingPromptQuery = useQuery({
+    queryKey: ['get', '/api/v1/prompts', editingPromptId],
+    queryFn: async () => {
+      if (!editingPromptId) return null
+      const { data, error } = await fetchClient.GET('/api/v1/prompts/{id}', {
+        params: { path: { id: editingPromptId } },
+      })
+      if (error) throw new Error('Failed to fetch prompt')
+      return data
+    },
+    enabled: !!editingPromptId,
+  })
+
+  function handleSaved() {
+    setView({ mode: 'list' })
+    queryClient.invalidateQueries({ queryKey: ['get', '/api/v1/prompts'] })
+  }
+
+  async function handleDelete(prompt: PromptResponse) {
+    if (!confirm(`Delete "${prompt.name}"? This cannot be undone.`)) return
+    await fetchClient.DELETE('/api/v1/prompts/{id}', {
+      params: { path: { id: prompt.id } },
+    })
+    queryClient.invalidateQueries({ queryKey: ['get', '/api/v1/prompts'] })
+  }
+
+  if (view.mode === 'create') {
+    return <PromptForm onSaved={handleSaved} onCancel={() => setView({ mode: 'list' })} />
+  }
+
+  if (view.mode === 'edit') {
+    if (editingPromptQuery.isPending) {
+      return (
+        <Center py="xl">
+          <Loader />
+        </Center>
+      )
+    }
+
+    if (editingPromptQuery.error || !editingPromptQuery.data) {
+      return (
+        <Alert color="red" variant="light">
+          Failed to load prompt.
+        </Alert>
+      )
+    }
+
+    return (
+      <PromptForm
+        prompt={editingPromptQuery.data}
+        onSaved={handleSaved}
+        onCancel={() => setView({ mode: 'list' })}
+      />
+    )
+  }
+
+  const prompts = promptsQuery.data?.prompts ?? []
+  const total = promptsQuery.data?.total ?? 0
+  const totalPages = Math.ceil(total / PAGE_SIZE)
+
+  return (
+    <>
+      <Group justify="space-between" align="center" mb="lg">
+        <Title order={2}>Prompts</Title>
+        <Button leftSection={<IconPlus size={16} />} onClick={() => setView({ mode: 'create' })}>
+          New Prompt
+        </Button>
+      </Group>
+
+      <Text size="sm" c="dimmed" mb="md">
+        Manage system instructions for your agents.
+      </Text>
+
+      {promptsQuery.isPending && (
+        <Center py="xl">
+          <Loader />
+        </Center>
+      )}
+
+      {promptsQuery.error && (
+        <Alert color="red" variant="light" mb="md">
+          Failed to load prompts.
+        </Alert>
+      )}
+
+      {!promptsQuery.isPending && prompts.length === 0 && (
+        <Text c="dimmed" ta="center" py="xl">
+          No prompts yet. Create your first prompt to get started.
+        </Text>
+      )}
+
+      <Stack gap="sm">
+        {prompts.map((prompt) => (
+          <PromptCard
+            key={prompt.id}
+            prompt={prompt}
+            onEdit={() => setView({ mode: 'edit', promptId: prompt.id })}
+            onDelete={() => handleDelete(prompt)}
+          />
+        ))}
+      </Stack>
+
+      {totalPages > 1 && (
+        <Center mt="lg">
+          <Pagination total={totalPages} value={page} onChange={setPage} />
+        </Center>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
This pull request introduces full CRUD (Create, Read, Update, Delete) support for managing prompts (system instructions) in the application. It adds the necessary database schema, repository, domain entity, application commands and queries, and exposes a new set of REST API endpoints for prompt management. The changes are grouped below by theme.

**Database and Repository Layer:**

- Adds a new `prompts` table to the SQLite database, including fields for `id`, `name`, `content`, `created_at`, and `updated_at`.
- Implements `PromptRepository` in `sqlite_prompt` with methods for listing, counting, retrieving, creating, updating, and deleting prompts.

**Domain and Application Layer:**

- Introduces the `Prompt` entity in the domain model, representing a system instruction with metadata.
- Adds application commands and queries for creating, updating, deleting, listing, and retrieving prompts, encapsulating business logic for each operation. [[1]](diffhunk://#diff-cc2c4dbbad091360f9c8aad67bf0aa343c1f40850f28d63726014464a7fd5fb5R1-R43) [[2]](diffhunk://#diff-111c5e7f707c7faea18156b41ed3f6ee5614272d977aa25500d08a147db4fe9cR1-R46) [[3]](diffhunk://#diff-73d094ce70ceebf74b061a846baf6a4a1240dc5fe0ab68f0614177aa073d3227R1-R23) [[4]](diffhunk://#diff-73d094ce70ceebf74b061a846baf6a4a1240dc5fe0ab68f0614177aa073d3227R1-R23) [[5]](diffhunk://#diff-c853e795f4668325d849eeeee7e316c5ccd00b2012ced120cb3fc31df2df4dbbR1-R56) [[6]](diffhunk://#diff-73d094ce70ceebf74b061a846baf6a4a1240dc5fe0ab68f0614177aa073d3227R1-R23) [[7]](diffhunk://#diff-73d094ce70ceebf74b061a846baf6a4a1240dc5fe0ab68f0614177aa073d3227R1-R23) [[8]](diffhunk://#diff-d21818aba14435e80d445bdd52e1247c5edab35b7b5a4a82bf906ce65921a516R1-R24)

**API Layer and Types:**

- Extends the OpenAPI-generated server interface and HTTP handler to support new endpoints: list, create, get, update, and delete prompts. [[1]](diffhunk://#diff-cb6d69ab6074be0c27581184c5d7bd66ae8686c70cd14d557a1119551cd57932R29-R43) [[2]](diffhunk://#diff-cb6d69ab6074be0c27581184c5d7bd66ae8686c70cd14d557a1119551cd57932R138-R261) [[3]](diffhunk://#diff-cb6d69ab6074be0c27581184c5d7bd66ae8686c70cd14d557a1119551cd57932R556-R560) [[4]](diffhunk://#diff-f7629283491bafbdb44edd199d18aeb60ef8b41cf3317589ff6bb6b35121af6dR24-R28)
- Defines new API types and request/response models for prompt operations, including pagination for listing and partial updates. [[1]](diffhunk://#diff-2e9bd033c6f339226e2389ca3bc94ed7bbef391a2620367def170636e99c1113R55-R63) [[2]](diffhunk://#diff-2e9bd033c6f339226e2389ca3bc94ed7bbef391a2620367def170636e99c1113R126-R158) [[3]](diffhunk://#diff-2e9bd033c6f339226e2389ca3bc94ed7bbef391a2620367def170636e99c1113R243-R251) [[4]](diffhunk://#diff-2e9bd033c6f339226e2389ca3bc94ed7bbef391a2620367def170636e99c1113R270-R284)

**Other:**

- Adds a new provider type constant `openai_compatible` to the supported provider types.

These changes collectively provide a robust foundation for prompt management within the system, enabling both backend and frontend to manage prompts through a consistent API.