### PR TITLE
feat: MCP server - expose all APIs as tools with guided agent creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Self-hostable platform for configuring and running LLM agents. Built on [Google 
 - [x] **Any LLM provider**: Google AI, OpenAI, Anthropic, Vertex AI, Bedrock, Azure, xAI, DeepSeek, Ollama
 - [x] **Agent builder UI**: Create agents with system prompts, model selection, temperature, and tool config
 - [x] **MCP tool support**: Connect tools via MCP servers (SSE and Streamable HTTP transports)
+- [x] **MCP server**: All management APIs exposed as [MCP tools](https://DEEJ4Y.github.io/genkitkraft/docs/guides/mcp-quickstart) — build agents on top of GenKitKraft with any MCP client
 - [x] **OpenAI-compatible API**: `/v1/chat/completions` with streaming support, works with any OpenAI client
 - [x] **Single binary**: Frontend embedded in the Go binary, SQLite by default, zero external dependencies
 - [ ] **Smart tool selection**: Three tool modes (manual, auto-search, hybrid) to avoid context pollution

--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ Self-hostable platform for configuring and running LLM agents. Built on [Google 
 - [x] **Single binary**: Frontend embedded in the Go binary, SQLite by default, zero external dependencies
 - [ ] **Smart tool selection**: Three tool modes (manual, auto-search, hybrid) to avoid context pollution
 
+## MCP Server — Build Agents Programmatically
+
+GenKitKraft exposes all management APIs as MCP tools. Connect any MCP client (Claude Desktop, Cursor, custom agents) to create providers, agents, prompts, and tools — no UI needed.
+
+```jsonc
+// Claude Desktop config (~/.config/Claude/claude_desktop_config.json)
+{
+  "mcpServers": {
+    "genkitkraft": {
+      "command": "npx",
+      "args": ["mcp-remote", "http://localhost:8080/mcp"]
+    }
+  }
+}
+```
+
+A built-in **`create-agent`** prompt guides the LLM through the full workflow. See the [MCP Quickstart](https://DEEJ4Y.github.io/genkitkraft/docs/guides/mcp-quickstart) and [Agent Creation Guide](https://DEEJ4Y.github.io/genkitkraft/docs/guides/mcp-agent-creation-guide) for details.
+
 ## Docs
 
 **[https://DEEJ4Y.github.io/genkitkraft/](https://DEEJ4Y.github.io/genkitkraft/)**

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/firebase/genkit/go v1.6.1
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.24
+	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/oapi-codegen/oapi-codegen/v2 v2.4.1
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/openai/openai-go v1.8.2
@@ -57,6 +58,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/dotprompt/go v0.0.0-20260227225921-0911cf9ecf0e // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.2 // indirect
@@ -75,6 +77,8 @@ require (
 	github.com/openai/openai-go/v3 v3.30.0 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/segmentio/asm v1.2.0 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect
 	github.com/speakeasy-api/openapi-overlay v0.9.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
@@ -98,6 +102,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
+	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/firebase/genkit/go v1.6.1 h1:8LpUjZ1Yd9JRRUfZU/m05aYWAKxGEkxHUkbhn+fuWdA=
 github.com/firebase/genkit/go v1.6.1/go.mod h1:FC5neH/nZJOqCQvMYodIy36cNZ1PWYJa2zkgkagfytg=
+github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
+github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -117,6 +119,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
@@ -166,6 +170,8 @@ github.com/mbleigh/raymond v0.0.0-20250414171441-6b3a58ab9e0a h1:v2cBA3xWKv2cIOV
 github.com/mbleigh/raymond v0.0.0-20250414171441-6b3a58ab9e0a/go.mod h1:Y6ghKH+ZijXn5d9E7qGGZBmjitx7iitZdQiIW97EpTU=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=
 github.com/mfridman/interpolate v0.0.2/go.mod h1:p+7uk6oE07mpE/Ik1b8EckO0O4ZXiGAfshKBWLUM9Xg=
+github.com/modelcontextprotocol/go-sdk v1.5.0 h1:CHU0FIX9kpueNkxuYtfYQn1Z0slhFzBZuq+x6IiblIU=
+github.com/modelcontextprotocol/go-sdk v1.5.0/go.mod h1:gggDIhoemhWs3BGkGwd1umzEXCEMMvAnhTrnbXJKKKA=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
@@ -210,6 +216,10 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
 github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
+github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
+github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah2SE=
@@ -291,6 +301,8 @@ golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
 golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
+golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
+golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/handlers/mcp_handler/agent_tool_config_tools.go
+++ b/internal/handlers/mcp_handler/agent_tool_config_tools.go
@@ -1,0 +1,103 @@
+package mcphandler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/DEEJ4Y/genkitkraft/internal/app/commands"
+	"github.com/DEEJ4Y/genkitkraft/internal/app/queries"
+	agenttoolrepo "github.com/DEEJ4Y/genkitkraft/internal/ports/agent_tool_repo"
+)
+
+// --- Input/Output types ---
+
+type GetAgentToolConfigInput struct {
+	AgentID string `json:"agent_id" jsonschema:"agent ID (required)"`
+}
+
+type McpServerToolConfigOutput struct {
+	McpServerID string   `json:"mcp_server_id"`
+	SelectAll   bool     `json:"select_all"`
+	ToolNames   []string `json:"tool_names,omitempty"`
+}
+
+type AgentToolConfigOutput struct {
+	AgentID     string                      `json:"agent_id"`
+	HttpToolIDs []string                    `json:"http_tool_ids"`
+	McpServers  []McpServerToolConfigOutput `json:"mcp_servers"`
+}
+
+type McpServerToolConfigInput struct {
+	McpServerID string   `json:"mcp_server_id" jsonschema:"MCP server ID"`
+	SelectAll   bool     `json:"select_all" jsonschema:"whether to include all tools from this server"`
+	ToolNames   []string `json:"tool_names,omitempty" jsonschema:"specific tool names to include (if select_all is false)"`
+}
+
+type UpdateAgentToolConfigInput struct {
+	AgentID     string                     `json:"agent_id" jsonschema:"agent ID (required)"`
+	HttpToolIDs []string                   `json:"http_tool_ids" jsonschema:"list of HTTP tool IDs to assign"`
+	McpServers  []McpServerToolConfigInput `json:"mcp_servers" jsonschema:"MCP server tool selections"`
+}
+
+// --- Tool registration ---
+
+func (h *Handler) registerAgentToolTools(s *mcp.Server) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "agent_tools_get",
+		Description: "Get the tool configuration for an agent (which HTTP tools and MCP servers are assigned).",
+	}, h.getAgentToolConfig)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "agent_tools_update",
+		Description: "Update the tool configuration for an agent. Replaces the entire configuration.",
+	}, h.updateAgentToolConfig)
+}
+
+// --- Tool handlers ---
+
+func (h *Handler) getAgentToolConfig(ctx context.Context, _ *mcp.CallToolRequest, input GetAgentToolConfigInput) (*mcp.CallToolResult, AgentToolConfigOutput, error) {
+	result, err := h.agentToolApp.Queries.GetTools.Execute(ctx, queries.GetAgentToolsParams{AgentID: input.AgentID})
+	if err != nil {
+		return nil, AgentToolConfigOutput{}, fmt.Errorf("get agent tools failed: %w", err)
+	}
+	return nil, toAgentToolConfigOutput(result.Config), nil
+}
+
+func (h *Handler) updateAgentToolConfig(ctx context.Context, _ *mcp.CallToolRequest, input UpdateAgentToolConfigInput) (*mcp.CallToolResult, AgentToolConfigOutput, error) {
+	mcpServers := make([]agenttoolrepo.McpServerToolConfig, len(input.McpServers))
+	for i, s := range input.McpServers {
+		mcpServers[i] = agenttoolrepo.McpServerToolConfig{
+			McpServerID: s.McpServerID,
+			SelectAll:   s.SelectAll,
+			ToolNames:   s.ToolNames,
+		}
+	}
+
+	result, err := h.agentToolApp.Commands.UpdateTools.Execute(ctx, commands.UpdateAgentToolsParams{
+		AgentID:     input.AgentID,
+		HttpToolIDs: input.HttpToolIDs,
+		McpServers:  mcpServers,
+	})
+	if err != nil {
+		return nil, AgentToolConfigOutput{}, fmt.Errorf("update agent tools failed: %w", err)
+	}
+	return nil, toAgentToolConfigOutput(result.Config), nil
+}
+
+func toAgentToolConfigOutput(cfg agenttoolrepo.AgentToolConfig) AgentToolConfigOutput {
+	mcpServers := make([]McpServerToolConfigOutput, len(cfg.McpServers))
+	for i, s := range cfg.McpServers {
+		mcpServers[i] = McpServerToolConfigOutput{
+			McpServerID: s.McpServerID,
+			SelectAll:   s.SelectAll,
+			ToolNames:   s.ToolNames,
+		}
+	}
+	return AgentToolConfigOutput{
+		AgentID:     cfg.AgentID,
+		HttpToolIDs: cfg.HttpToolIDs,
+		McpServers:  mcpServers,
+	}
+}

--- a/internal/handlers/mcp_handler/agent_tools.go
+++ b/internal/handlers/mcp_handler/agent_tools.go
@@ -1,0 +1,203 @@
+package mcphandler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/DEEJ4Y/genkitkraft/internal/app/commands"
+	"github.com/DEEJ4Y/genkitkraft/internal/app/queries"
+	"github.com/DEEJ4Y/genkitkraft/internal/domain/agent"
+)
+
+// --- Input/Output types ---
+
+type ListAgentsInput struct {
+	Limit  int `json:"limit" jsonschema:"max number of agents to return (default 20, max 100)"`
+	Offset int `json:"offset" jsonschema:"offset for pagination"`
+}
+
+type AgentOutput struct {
+	ID                 string    `json:"id"`
+	Name               string    `json:"name"`
+	ProviderID         string    `json:"provider_id"`
+	ModelID            string    `json:"model_id"`
+	SystemPromptID     string    `json:"system_prompt_id,omitempty"`
+	TemperatureEnabled bool      `json:"temperature_enabled"`
+	Temperature        float64   `json:"temperature"`
+	TopPEnabled        bool      `json:"top_p_enabled"`
+	TopP               float64   `json:"top_p"`
+	TopKEnabled        bool      `json:"top_k_enabled"`
+	TopK               int       `json:"top_k"`
+	ProviderName       string    `json:"provider_name,omitempty"`
+	ProviderType       string    `json:"provider_type,omitempty"`
+	SystemPromptName   string    `json:"system_prompt_name,omitempty"`
+	CreatedAt          time.Time `json:"created_at"`
+	UpdatedAt          time.Time `json:"updated_at"`
+}
+
+type ListAgentsOutput struct {
+	Agents []AgentOutput `json:"agents"`
+	Total  int           `json:"total"`
+}
+
+type GetAgentInput struct {
+	ID string `json:"id" jsonschema:"agent ID"`
+}
+
+type CreateAgentInput struct {
+	Name               string   `json:"name" jsonschema:"agent name (required)"`
+	ProviderID         string   `json:"provider_id" jsonschema:"LLM provider ID (required)"`
+	ModelID            string   `json:"model_id" jsonschema:"model identifier (required)"`
+	SystemPromptID     string   `json:"system_prompt_id,omitempty" jsonschema:"system prompt ID"`
+	TemperatureEnabled *bool    `json:"temperature_enabled,omitempty" jsonschema:"enable temperature sampling"`
+	Temperature        *float64 `json:"temperature,omitempty" jsonschema:"temperature value (0-2)"`
+	TopPEnabled        *bool    `json:"top_p_enabled,omitempty" jsonschema:"enable top-p sampling"`
+	TopP               *float64 `json:"top_p,omitempty" jsonschema:"top-p value (0-1)"`
+	TopKEnabled        *bool    `json:"top_k_enabled,omitempty" jsonschema:"enable top-k sampling"`
+	TopK               *int     `json:"top_k,omitempty" jsonschema:"top-k value"`
+}
+
+type UpdateAgentInput struct {
+	ID                 string   `json:"id" jsonschema:"agent ID (required)"`
+	Name               *string  `json:"name,omitempty" jsonschema:"new agent name"`
+	ProviderID         *string  `json:"provider_id,omitempty" jsonschema:"new provider ID"`
+	ModelID            *string  `json:"model_id,omitempty" jsonschema:"new model ID"`
+	SystemPromptID     *string  `json:"system_prompt_id,omitempty" jsonschema:"new system prompt ID (empty string to clear)"`
+	TemperatureEnabled *bool    `json:"temperature_enabled,omitempty" jsonschema:"enable temperature sampling"`
+	Temperature        *float64 `json:"temperature,omitempty" jsonschema:"temperature value"`
+	TopPEnabled        *bool    `json:"top_p_enabled,omitempty" jsonschema:"enable top-p sampling"`
+	TopP               *float64 `json:"top_p,omitempty" jsonschema:"top-p value"`
+	TopKEnabled        *bool    `json:"top_k_enabled,omitempty" jsonschema:"enable top-k sampling"`
+	TopK               *int     `json:"top_k,omitempty" jsonschema:"top-k value"`
+}
+
+type DeleteAgentInput struct {
+	ID string `json:"id" jsonschema:"agent ID to delete"`
+}
+
+// --- Tool registration ---
+
+func (h *Handler) registerAgentTools(s *mcp.Server) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "agents_list",
+		Description: "List all agents with pagination.",
+	}, h.listAgents)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "agents_get",
+		Description: "Get a single agent by ID.",
+	}, h.getAgent)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "agents_create",
+		Description: "Create a new agent with a provider, model, and optional system prompt.",
+	}, h.createAgent)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "agents_update",
+		Description: "Update an existing agent. Only provided fields are changed.",
+	}, h.updateAgent)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "agents_delete",
+		Description: "Delete an agent by ID.",
+	}, h.deleteAgent)
+}
+
+// --- Tool handlers ---
+
+func (h *Handler) listAgents(ctx context.Context, _ *mcp.CallToolRequest, input ListAgentsInput) (*mcp.CallToolResult, ListAgentsOutput, error) {
+	result, err := h.agentApp.Queries.ListAgents.Execute(ctx, queries.ListAgentsParams{
+		Limit:  input.Limit,
+		Offset: input.Offset,
+	})
+	if err != nil {
+		return nil, ListAgentsOutput{}, fmt.Errorf("list agents failed: %w", err)
+	}
+	agents := make([]AgentOutput, len(result.Agents))
+	for i, a := range result.Agents {
+		agents[i] = toAgentOutput(a)
+	}
+	return nil, ListAgentsOutput{Agents: agents, Total: result.Total}, nil
+}
+
+func (h *Handler) getAgent(ctx context.Context, _ *mcp.CallToolRequest, input GetAgentInput) (*mcp.CallToolResult, AgentOutput, error) {
+	result, err := h.agentApp.Queries.GetAgent.Execute(ctx, queries.GetAgentParams{ID: input.ID})
+	if err != nil {
+		return nil, AgentOutput{}, fmt.Errorf("get agent failed: %w", err)
+	}
+	return nil, toAgentOutput(result.Agent), nil
+}
+
+func (h *Handler) createAgent(ctx context.Context, _ *mcp.CallToolRequest, input CreateAgentInput) (*mcp.CallToolResult, AgentOutput, error) {
+	result, err := h.agentApp.Commands.CreateAgent.Execute(ctx, commands.CreateAgentParams{
+		Name:               input.Name,
+		ProviderID:         input.ProviderID,
+		ModelID:            input.ModelID,
+		SystemPromptID:     input.SystemPromptID,
+		TemperatureEnabled: input.TemperatureEnabled,
+		Temperature:        input.Temperature,
+		TopPEnabled:        input.TopPEnabled,
+		TopP:               input.TopP,
+		TopKEnabled:        input.TopKEnabled,
+		TopK:               input.TopK,
+	})
+	if err != nil {
+		return nil, AgentOutput{}, fmt.Errorf("create agent failed: %w", err)
+	}
+	return nil, toAgentOutput(result.Agent), nil
+}
+
+func (h *Handler) updateAgent(ctx context.Context, _ *mcp.CallToolRequest, input UpdateAgentInput) (*mcp.CallToolResult, AgentOutput, error) {
+	result, err := h.agentApp.Commands.UpdateAgent.Execute(ctx, commands.UpdateAgentParams{
+		ID:                 input.ID,
+		Name:               input.Name,
+		ProviderID:         input.ProviderID,
+		ModelID:            input.ModelID,
+		SystemPromptID:     input.SystemPromptID,
+		TemperatureEnabled: input.TemperatureEnabled,
+		Temperature:        input.Temperature,
+		TopPEnabled:        input.TopPEnabled,
+		TopP:               input.TopP,
+		TopKEnabled:        input.TopKEnabled,
+		TopK:               input.TopK,
+	})
+	if err != nil {
+		return nil, AgentOutput{}, fmt.Errorf("update agent failed: %w", err)
+	}
+	return nil, toAgentOutput(result.Agent), nil
+}
+
+func (h *Handler) deleteAgent(ctx context.Context, _ *mcp.CallToolRequest, input DeleteAgentInput) (*mcp.CallToolResult, any, error) {
+	err := h.agentApp.Commands.DeleteAgent.Execute(ctx, commands.DeleteAgentParams{ID: input.ID})
+	if err != nil {
+		return nil, nil, fmt.Errorf("delete agent failed: %w", err)
+	}
+	return nil, map[string]string{"status": "deleted"}, nil
+}
+
+// --- Helpers ---
+
+func toAgentOutput(a *agent.Agent) AgentOutput {
+	return AgentOutput{
+		ID:                 a.ID,
+		Name:               a.Name,
+		ProviderID:         a.ProviderID,
+		ModelID:            a.ModelID,
+		SystemPromptID:     a.SystemPromptID,
+		TemperatureEnabled: a.TemperatureEnabled,
+		Temperature:        a.Temperature,
+		TopPEnabled:        a.TopPEnabled,
+		TopP:               a.TopP,
+		TopKEnabled:        a.TopKEnabled,
+		TopK:               a.TopK,
+		ProviderName:       a.ProviderName,
+		ProviderType:       a.ProviderType,
+		SystemPromptName:   a.SystemPromptName,
+		CreatedAt:          a.CreatedAt,
+		UpdatedAt:          a.UpdatedAt,
+	}
+}

--- a/internal/handlers/mcp_handler/auth_middleware.go
+++ b/internal/handlers/mcp_handler/auth_middleware.go
@@ -1,0 +1,39 @@
+package mcphandler
+
+import (
+	"crypto/subtle"
+	"net/http"
+
+	"github.com/DEEJ4Y/genkitkraft/internal/config"
+)
+
+// basicAuthMiddleware wraps an http.Handler with HTTP Basic Authentication.
+// It validates the provided username:password against the configured credentials.
+func basicAuthMiddleware(next http.Handler, credentials []config.AuthCredential) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok {
+			w.Header().Set("WWW-Authenticate", `Basic realm="GenKitKraft MCP"`)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		if !validateCredentials(username, password, credentials) {
+			w.Header().Set("WWW-Authenticate", `Basic realm="GenKitKraft MCP"`)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func validateCredentials(username, password string, credentials []config.AuthCredential) bool {
+	for _, cred := range credentials {
+		if subtle.ConstantTimeCompare([]byte(username), []byte(cred.Username)) == 1 &&
+			subtle.ConstantTimeCompare([]byte(password), []byte(cred.Password)) == 1 {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/handlers/mcp_handler/auth_tools.go
+++ b/internal/handlers/mcp_handler/auth_tools.go
@@ -1,0 +1,100 @@
+package mcphandler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/DEEJ4Y/genkitkraft/internal/app/commands"
+	"github.com/DEEJ4Y/genkitkraft/internal/app/queries"
+)
+
+// --- Input/Output types ---
+
+type LoginInput struct {
+	Username string `json:"username" jsonschema:"username for authentication"`
+	Password string `json:"password" jsonschema:"password for authentication"`
+}
+
+type LoginOutput struct {
+	Token    string `json:"token"`
+	Username string `json:"username"`
+}
+
+type LogoutInput struct {
+	Token string `json:"token" jsonschema:"session token to invalidate"`
+}
+
+type GetMeInput struct {
+	Token string `json:"token" jsonschema:"session token"`
+}
+
+type GetMeOutput struct {
+	Username string `json:"username"`
+}
+
+type AuthStatusOutput struct {
+	Required bool `json:"required"`
+}
+
+// --- Tool registration ---
+
+func (h *Handler) registerAuthTools(s *mcp.Server) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "auth_login",
+		Description: "Authenticate with username and password. Returns a session token.",
+	}, h.authLogin)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "auth_logout",
+		Description: "Invalidate a session token.",
+	}, h.authLogout)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "auth_get_me",
+		Description: "Get the username associated with a session token.",
+	}, h.authGetMe)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "auth_get_status",
+		Description: "Check whether authentication is required.",
+	}, h.authGetStatus)
+}
+
+// --- Tool handlers ---
+
+func (h *Handler) authLogin(ctx context.Context, _ *mcp.CallToolRequest, input LoginInput) (*mcp.CallToolResult, LoginOutput, error) {
+	result, err := h.authApp.Commands.Login.Execute(ctx, commands.LoginParams{
+		Username: input.Username,
+		Password: input.Password,
+	})
+	if err != nil {
+		return nil, LoginOutput{}, fmt.Errorf("login failed: %w", err)
+	}
+	return nil, LoginOutput{Token: result.Token, Username: result.Username}, nil
+}
+
+func (h *Handler) authLogout(ctx context.Context, _ *mcp.CallToolRequest, input LogoutInput) (*mcp.CallToolResult, any, error) {
+	err := h.authApp.Commands.Logout.Execute(ctx, commands.LogoutParams{Token: input.Token})
+	if err != nil {
+		return nil, nil, fmt.Errorf("logout failed: %w", err)
+	}
+	return nil, map[string]string{"status": "ok"}, nil
+}
+
+func (h *Handler) authGetMe(ctx context.Context, _ *mcp.CallToolRequest, input GetMeInput) (*mcp.CallToolResult, GetMeOutput, error) {
+	result, err := h.authApp.Queries.GetMe.Execute(ctx, queries.GetMeParams{Token: input.Token})
+	if err != nil {
+		return nil, GetMeOutput{}, fmt.Errorf("get me failed: %w", err)
+	}
+	return nil, GetMeOutput{Username: result.Username}, nil
+}
+
+func (h *Handler) authGetStatus(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, AuthStatusOutput, error) {
+	result, err := h.authApp.Queries.GetAuthStatus.Execute(ctx, queries.GetAuthStatusParams{})
+	if err != nil {
+		return nil, AuthStatusOutput{}, fmt.Errorf("get auth status failed: %w", err)
+	}
+	return nil, AuthStatusOutput{Required: result.Required}, nil
+}

--- a/internal/handlers/mcp_handler/handler.go
+++ b/internal/handlers/mcp_handler/handler.go
@@ -1,0 +1,85 @@
+package mcphandler
+
+import (
+	"net/http"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/DEEJ4Y/genkitkraft/internal/app"
+	"github.com/DEEJ4Y/genkitkraft/internal/config"
+	chatprovider "github.com/DEEJ4Y/genkitkraft/internal/ports/chat_provider"
+	mcpdiscovery "github.com/DEEJ4Y/genkitkraft/internal/ports/mcp_discovery"
+)
+
+// Handler registers all GenKitKraft APIs as MCP tools and serves them
+// over the StreamableHTTP transport.
+type Handler struct {
+	authApp       *app.AuthApp
+	providerApp   *app.ProviderApp
+	promptApp     *app.PromptApp
+	agentApp      *app.AgentApp
+	playgroundApp *app.PlaygroundApp
+	httpToolApp   *app.HttpToolApp
+	mcpServerApp  *app.McpServerApp
+	agentToolApp  *app.AgentToolApp
+	chatProvider  chatprovider.ChatProvider
+	mcpDiscovery  mcpdiscovery.McpDiscovery
+	authCfg       config.AuthConfig
+}
+
+func NewHandler(
+	authApp *app.AuthApp,
+	providerApp *app.ProviderApp,
+	promptApp *app.PromptApp,
+	agentApp *app.AgentApp,
+	playgroundApp *app.PlaygroundApp,
+	httpToolApp *app.HttpToolApp,
+	mcpServerApp *app.McpServerApp,
+	agentToolApp *app.AgentToolApp,
+	chatProvider chatprovider.ChatProvider,
+	mcpDiscovery mcpdiscovery.McpDiscovery,
+	authCfg config.AuthConfig,
+) *Handler {
+	return &Handler{
+		authApp:       authApp,
+		providerApp:   providerApp,
+		promptApp:     promptApp,
+		agentApp:      agentApp,
+		playgroundApp: playgroundApp,
+		httpToolApp:   httpToolApp,
+		mcpServerApp:  mcpServerApp,
+		agentToolApp:  agentToolApp,
+		chatProvider:  chatProvider,
+		mcpDiscovery:  mcpDiscovery,
+		authCfg:       authCfg,
+	}
+}
+
+// HTTPHandler builds an MCP server with all registered tools and returns
+// an http.Handler ready to be mounted on a ServeMux. If AUTH_CREDENTIALS is
+// configured, the handler is wrapped with HTTP basic auth.
+func (h *Handler) HTTPHandler() http.Handler {
+	server := mcp.NewServer(
+		&mcp.Implementation{Name: "genkitkraft", Version: "v1.0.0"},
+		nil,
+	)
+
+	h.registerAuthTools(server)
+	h.registerAgentTools(server)
+	h.registerAgentToolTools(server)
+	h.registerPromptTools(server)
+	h.registerProviderTools(server)
+	h.registerHttpToolTools(server)
+	h.registerMcpServerTools(server)
+	h.registerPlaygroundTools(server)
+	h.registerHealthTools(server)
+
+	handler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
+		return server
+	}, nil)
+
+	if len(h.authCfg.Credentials) > 0 {
+		return basicAuthMiddleware(handler, h.authCfg.Credentials)
+	}
+	return handler
+}

--- a/internal/handlers/mcp_handler/handler.go
+++ b/internal/handlers/mcp_handler/handler.go
@@ -73,6 +73,7 @@ func (h *Handler) HTTPHandler() http.Handler {
 	h.registerMcpServerTools(server)
 	h.registerPlaygroundTools(server)
 	h.registerHealthTools(server)
+	h.registerPrompts(server)
 
 	handler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
 		return server

--- a/internal/handlers/mcp_handler/health_tools.go
+++ b/internal/handlers/mcp_handler/health_tools.go
@@ -1,0 +1,37 @@
+package mcphandler
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// --- Output types ---
+
+type HealthOutput struct {
+	Status string `json:"status"`
+}
+
+// --- Tool registration ---
+
+func (h *Handler) registerHealthTools(s *mcp.Server) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "health_liveness",
+		Description: "Check if the server is alive.",
+	}, h.healthLiveness)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "health_readiness",
+		Description: "Check if the server is ready to accept requests.",
+	}, h.healthReadiness)
+}
+
+// --- Tool handlers ---
+
+func (h *Handler) healthLiveness(_ context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, HealthOutput, error) {
+	return nil, HealthOutput{Status: "ok"}, nil
+}
+
+func (h *Handler) healthReadiness(_ context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, HealthOutput, error) {
+	return nil, HealthOutput{Status: "ok"}, nil
+}

--- a/internal/handlers/mcp_handler/http_tool_tools.go
+++ b/internal/handlers/mcp_handler/http_tool_tools.go
@@ -1,0 +1,202 @@
+package mcphandler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/DEEJ4Y/genkitkraft/internal/app/commands"
+	"github.com/DEEJ4Y/genkitkraft/internal/app/queries"
+	httptool "github.com/DEEJ4Y/genkitkraft/internal/domain/http_tool"
+)
+
+// --- Input/Output types ---
+
+type ListHttpToolsInput struct {
+	Limit  int `json:"limit" jsonschema:"max number of HTTP tools to return (default 20, max 100)"`
+	Offset int `json:"offset" jsonschema:"offset for pagination"`
+}
+
+type HttpToolHeaderOutput struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type HttpToolOutput struct {
+	ID           string                 `json:"id"`
+	Name         string                 `json:"name"`
+	Description  string                 `json:"description"`
+	Method       string                 `json:"method"`
+	URL          string                 `json:"url"`
+	Headers      []HttpToolHeaderOutput `json:"headers,omitempty"`
+	BodyTemplate string                 `json:"body_template,omitempty"`
+	InputSchema  string                 `json:"input_schema,omitempty"`
+	CreatedAt    time.Time              `json:"created_at"`
+	UpdatedAt    time.Time              `json:"updated_at"`
+}
+
+type ListHttpToolsOutput struct {
+	HttpTools []HttpToolOutput `json:"http_tools"`
+	Total     int              `json:"total"`
+}
+
+type GetHttpToolInput struct {
+	ID string `json:"id" jsonschema:"HTTP tool ID"`
+}
+
+type HttpToolHeaderInput struct {
+	Name  string `json:"name" jsonschema:"header name"`
+	Value string `json:"value" jsonschema:"header value"`
+}
+
+type CreateHttpToolInput struct {
+	Name         string                `json:"name" jsonschema:"tool name (required)"`
+	Description  string                `json:"description" jsonschema:"tool description (required)"`
+	Method       string                `json:"method" jsonschema:"HTTP method: GET, POST, PUT, DELETE, PATCH (required)"`
+	URL          string                `json:"url" jsonschema:"URL template (required)"`
+	Headers      []HttpToolHeaderInput `json:"headers,omitempty" jsonschema:"request headers"`
+	BodyTemplate string                `json:"body_template,omitempty" jsonschema:"request body template with {{placeholders}}"`
+	InputSchema  string                `json:"input_schema,omitempty" jsonschema:"JSON schema for tool input parameters"`
+}
+
+type UpdateHttpToolInput struct {
+	ID           string                 `json:"id" jsonschema:"HTTP tool ID (required)"`
+	Name         *string                `json:"name,omitempty" jsonschema:"new tool name"`
+	Description  *string                `json:"description,omitempty" jsonschema:"new description"`
+	Method       *string                `json:"method,omitempty" jsonschema:"new HTTP method"`
+	URL          *string                `json:"url,omitempty" jsonschema:"new URL template"`
+	Headers      *[]HttpToolHeaderInput `json:"headers,omitempty" jsonschema:"new headers"`
+	BodyTemplate *string                `json:"body_template,omitempty" jsonschema:"new body template"`
+	InputSchema  *string                `json:"input_schema,omitempty" jsonschema:"new input schema"`
+}
+
+type DeleteHttpToolInput struct {
+	ID string `json:"id" jsonschema:"HTTP tool ID to delete"`
+}
+
+// --- Tool registration ---
+
+func (h *Handler) registerHttpToolTools(s *mcp.Server) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "http_tools_list",
+		Description: "List all HTTP tools with pagination.",
+	}, h.listHttpTools)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "http_tools_get",
+		Description: "Get an HTTP tool by ID.",
+	}, h.getHttpTool)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "http_tools_create",
+		Description: "Create a new HTTP tool (custom API call).",
+	}, h.createHttpTool)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "http_tools_update",
+		Description: "Update an existing HTTP tool. Only provided fields are changed.",
+	}, h.updateHttpTool)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "http_tools_delete",
+		Description: "Delete an HTTP tool by ID.",
+	}, h.deleteHttpTool)
+}
+
+// --- Tool handlers ---
+
+func (h *Handler) listHttpTools(ctx context.Context, _ *mcp.CallToolRequest, input ListHttpToolsInput) (*mcp.CallToolResult, ListHttpToolsOutput, error) {
+	result, err := h.httpToolApp.Queries.ListHttpTools.Execute(ctx, queries.ListHttpToolsParams{
+		Limit:  input.Limit,
+		Offset: input.Offset,
+	})
+	if err != nil {
+		return nil, ListHttpToolsOutput{}, fmt.Errorf("list http tools failed: %w", err)
+	}
+	tools := make([]HttpToolOutput, len(result.HttpTools))
+	for i, t := range result.HttpTools {
+		tools[i] = toHttpToolOutput(t)
+	}
+	return nil, ListHttpToolsOutput{HttpTools: tools, Total: result.Total}, nil
+}
+
+func (h *Handler) getHttpTool(ctx context.Context, _ *mcp.CallToolRequest, input GetHttpToolInput) (*mcp.CallToolResult, HttpToolOutput, error) {
+	result, err := h.httpToolApp.Queries.GetHttpTool.Execute(ctx, queries.GetHttpToolParams{ID: input.ID})
+	if err != nil {
+		return nil, HttpToolOutput{}, fmt.Errorf("get http tool failed: %w", err)
+	}
+	return nil, toHttpToolOutput(result.HttpTool), nil
+}
+
+func (h *Handler) createHttpTool(ctx context.Context, _ *mcp.CallToolRequest, input CreateHttpToolInput) (*mcp.CallToolResult, HttpToolOutput, error) {
+	headers := make([]httptool.HttpToolHeader, len(input.Headers))
+	for i, hdr := range input.Headers {
+		headers[i] = httptool.HttpToolHeader{Name: hdr.Name, Value: hdr.Value}
+	}
+	result, err := h.httpToolApp.Commands.CreateHttpTool.Execute(ctx, commands.CreateHttpToolParams{
+		Name:         input.Name,
+		Description:  input.Description,
+		Method:       input.Method,
+		URL:          input.URL,
+		Headers:      headers,
+		BodyTemplate: input.BodyTemplate,
+		InputSchema:  input.InputSchema,
+	})
+	if err != nil {
+		return nil, HttpToolOutput{}, fmt.Errorf("create http tool failed: %w", err)
+	}
+	return nil, toHttpToolOutput(result.HttpTool), nil
+}
+
+func (h *Handler) updateHttpTool(ctx context.Context, _ *mcp.CallToolRequest, input UpdateHttpToolInput) (*mcp.CallToolResult, HttpToolOutput, error) {
+	params := commands.UpdateHttpToolParams{
+		ID:           input.ID,
+		Name:         input.Name,
+		Description:  input.Description,
+		Method:       input.Method,
+		URL:          input.URL,
+		BodyTemplate: input.BodyTemplate,
+		InputSchema:  input.InputSchema,
+	}
+	if input.Headers != nil {
+		headers := make([]httptool.HttpToolHeader, len(*input.Headers))
+		for i, hdr := range *input.Headers {
+			headers[i] = httptool.HttpToolHeader{Name: hdr.Name, Value: hdr.Value}
+		}
+		params.Headers = &headers
+	}
+	result, err := h.httpToolApp.Commands.UpdateHttpTool.Execute(ctx, params)
+	if err != nil {
+		return nil, HttpToolOutput{}, fmt.Errorf("update http tool failed: %w", err)
+	}
+	return nil, toHttpToolOutput(result.HttpTool), nil
+}
+
+func (h *Handler) deleteHttpTool(ctx context.Context, _ *mcp.CallToolRequest, input DeleteHttpToolInput) (*mcp.CallToolResult, any, error) {
+	err := h.httpToolApp.Commands.DeleteHttpTool.Execute(ctx, commands.DeleteHttpToolParams{ID: input.ID})
+	if err != nil {
+		return nil, nil, fmt.Errorf("delete http tool failed: %w", err)
+	}
+	return nil, map[string]string{"status": "deleted"}, nil
+}
+
+func toHttpToolOutput(t *httptool.HttpTool) HttpToolOutput {
+	headers := make([]HttpToolHeaderOutput, len(t.Headers))
+	for i, hdr := range t.Headers {
+		headers[i] = HttpToolHeaderOutput{Name: hdr.Name, Value: hdr.Value}
+	}
+	return HttpToolOutput{
+		ID:           t.ID,
+		Name:         t.Name,
+		Description:  t.Description,
+		Method:       t.Method,
+		URL:          t.URL,
+		Headers:      headers,
+		BodyTemplate: t.BodyTemplate,
+		InputSchema:  t.InputSchema,
+		CreatedAt:    t.CreatedAt,
+		UpdatedAt:    t.UpdatedAt,
+	}
+}

--- a/internal/handlers/mcp_handler/mcp_server_tools.go
+++ b/internal/handlers/mcp_handler/mcp_server_tools.go
@@ -1,0 +1,227 @@
+package mcphandler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/DEEJ4Y/genkitkraft/internal/app/commands"
+	"github.com/DEEJ4Y/genkitkraft/internal/app/queries"
+	mcpserver "github.com/DEEJ4Y/genkitkraft/internal/domain/mcp_server"
+)
+
+// --- Input/Output types ---
+
+type ListMcpServersInput struct {
+	Limit  int `json:"limit" jsonschema:"max number of MCP servers to return (default 20, max 100)"`
+	Offset int `json:"offset" jsonschema:"offset for pagination"`
+}
+
+type McpServerHeaderOutput struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type McpServerOutput struct {
+	ID        string                  `json:"id"`
+	Name      string                  `json:"name"`
+	Transport string                  `json:"transport"`
+	URL       string                  `json:"url"`
+	Headers   []McpServerHeaderOutput `json:"headers,omitempty"`
+	CreatedAt time.Time               `json:"created_at"`
+	UpdatedAt time.Time               `json:"updated_at"`
+}
+
+type ListMcpServersOutput struct {
+	McpServers []McpServerOutput `json:"mcp_servers"`
+	Total      int               `json:"total"`
+}
+
+type GetMcpServerInput struct {
+	ID string `json:"id" jsonschema:"MCP server ID"`
+}
+
+type McpServerHeaderInput struct {
+	Name  string `json:"name" jsonschema:"header name"`
+	Value string `json:"value" jsonschema:"header value"`
+}
+
+type CreateMcpServerInput struct {
+	Name      string                 `json:"name" jsonschema:"server name (required)"`
+	Transport string                 `json:"transport" jsonschema:"transport type: sse or streamableHttp (required)"`
+	URL       string                 `json:"url" jsonschema:"server URL (required)"`
+	Headers   []McpServerHeaderInput `json:"headers,omitempty" jsonschema:"custom headers for MCP server requests"`
+}
+
+type UpdateMcpServerInput struct {
+	ID        string                  `json:"id" jsonschema:"MCP server ID (required)"`
+	Name      *string                 `json:"name,omitempty" jsonschema:"new server name"`
+	Transport *string                 `json:"transport,omitempty" jsonschema:"new transport type"`
+	URL       *string                 `json:"url,omitempty" jsonschema:"new server URL"`
+	Headers   *[]McpServerHeaderInput `json:"headers,omitempty" jsonschema:"new headers"`
+}
+
+type DeleteMcpServerInput struct {
+	ID string `json:"id" jsonschema:"MCP server ID to delete"`
+}
+
+type ListMcpServerToolsInput struct {
+	ID string `json:"id" jsonschema:"MCP server ID to list tools from"`
+}
+
+type McpServerToolOutput struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type ListMcpServerToolsOutput struct {
+	Tools []McpServerToolOutput `json:"tools"`
+}
+
+// --- Tool registration ---
+
+func (h *Handler) registerMcpServerTools(s *mcp.Server) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "mcp_servers_list",
+		Description: "List all configured MCP tool servers with pagination.",
+	}, h.listMcpServers)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "mcp_servers_get",
+		Description: "Get an MCP tool server by ID.",
+	}, h.getMcpServer)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "mcp_servers_create",
+		Description: "Register a new MCP tool server.",
+	}, h.createMcpServer)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "mcp_servers_update",
+		Description: "Update an existing MCP tool server. Only provided fields are changed.",
+	}, h.updateMcpServer)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "mcp_servers_delete",
+		Description: "Delete an MCP tool server by ID.",
+	}, h.deleteMcpServer)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "mcp_servers_list_tools",
+		Description: "Connect to an MCP tool server and list its available tools.",
+	}, h.listMcpServerToolsHandler)
+}
+
+// --- Tool handlers ---
+
+func (h *Handler) listMcpServers(ctx context.Context, _ *mcp.CallToolRequest, input ListMcpServersInput) (*mcp.CallToolResult, ListMcpServersOutput, error) {
+	result, err := h.mcpServerApp.Queries.ListMcpServers.Execute(ctx, queries.ListMcpServersParams{
+		Limit:  input.Limit,
+		Offset: input.Offset,
+	})
+	if err != nil {
+		return nil, ListMcpServersOutput{}, fmt.Errorf("list mcp servers failed: %w", err)
+	}
+	servers := make([]McpServerOutput, len(result.McpServers))
+	for i, s := range result.McpServers {
+		servers[i] = toMcpServerOutput(s)
+	}
+	return nil, ListMcpServersOutput{McpServers: servers, Total: result.Total}, nil
+}
+
+func (h *Handler) getMcpServer(ctx context.Context, _ *mcp.CallToolRequest, input GetMcpServerInput) (*mcp.CallToolResult, McpServerOutput, error) {
+	result, err := h.mcpServerApp.Queries.GetMcpServer.Execute(ctx, queries.GetMcpServerParams{ID: input.ID})
+	if err != nil {
+		return nil, McpServerOutput{}, fmt.Errorf("get mcp server failed: %w", err)
+	}
+	return nil, toMcpServerOutput(result.McpServer), nil
+}
+
+func (h *Handler) createMcpServer(ctx context.Context, _ *mcp.CallToolRequest, input CreateMcpServerInput) (*mcp.CallToolResult, McpServerOutput, error) {
+	headers := make([]mcpserver.McpServerHeader, len(input.Headers))
+	for i, hdr := range input.Headers {
+		headers[i] = mcpserver.McpServerHeader{Name: hdr.Name, Value: hdr.Value}
+	}
+	result, err := h.mcpServerApp.Commands.CreateMcpServer.Execute(ctx, commands.CreateMcpServerParams{
+		Name:      input.Name,
+		Transport: input.Transport,
+		URL:       input.URL,
+		Headers:   headers,
+	})
+	if err != nil {
+		return nil, McpServerOutput{}, fmt.Errorf("create mcp server failed: %w", err)
+	}
+	return nil, toMcpServerOutput(result.McpServer), nil
+}
+
+func (h *Handler) updateMcpServer(ctx context.Context, _ *mcp.CallToolRequest, input UpdateMcpServerInput) (*mcp.CallToolResult, McpServerOutput, error) {
+	params := commands.UpdateMcpServerParams{
+		ID:        input.ID,
+		Name:      input.Name,
+		Transport: input.Transport,
+		URL:       input.URL,
+	}
+	if input.Headers != nil {
+		headers := make([]mcpserver.McpServerHeader, len(*input.Headers))
+		for i, hdr := range *input.Headers {
+			headers[i] = mcpserver.McpServerHeader{Name: hdr.Name, Value: hdr.Value}
+		}
+		params.Headers = &headers
+	}
+	result, err := h.mcpServerApp.Commands.UpdateMcpServer.Execute(ctx, params)
+	if err != nil {
+		return nil, McpServerOutput{}, fmt.Errorf("update mcp server failed: %w", err)
+	}
+	return nil, toMcpServerOutput(result.McpServer), nil
+}
+
+func (h *Handler) deleteMcpServer(ctx context.Context, _ *mcp.CallToolRequest, input DeleteMcpServerInput) (*mcp.CallToolResult, any, error) {
+	err := h.mcpServerApp.Commands.DeleteMcpServer.Execute(ctx, commands.DeleteMcpServerParams{ID: input.ID})
+	if err != nil {
+		return nil, nil, fmt.Errorf("delete mcp server failed: %w", err)
+	}
+	return nil, map[string]string{"status": "deleted"}, nil
+}
+
+func (h *Handler) listMcpServerToolsHandler(ctx context.Context, _ *mcp.CallToolRequest, input ListMcpServerToolsInput) (*mcp.CallToolResult, ListMcpServerToolsOutput, error) {
+	result, err := h.mcpServerApp.Queries.GetMcpServer.Execute(ctx, queries.GetMcpServerParams{ID: input.ID})
+	if err != nil {
+		return nil, ListMcpServerToolsOutput{}, fmt.Errorf("get mcp server failed: %w", err)
+	}
+
+	server := result.McpServer
+	headerMap := make(map[string]string, len(server.Headers))
+	for _, hdr := range server.Headers {
+		headerMap[hdr.Name] = hdr.Value
+	}
+
+	tools, err := h.mcpDiscovery.ListTools(ctx, server.Name, server.Transport, server.URL, headerMap)
+	if err != nil {
+		// Return empty list on discovery failure (matches HTTP handler behavior)
+		return nil, ListMcpServerToolsOutput{Tools: []McpServerToolOutput{}}, nil
+	}
+
+	out := make([]McpServerToolOutput, len(tools))
+	for i, t := range tools {
+		out[i] = McpServerToolOutput{Name: t.Name, Description: t.Description}
+	}
+	return nil, ListMcpServerToolsOutput{Tools: out}, nil
+}
+
+func toMcpServerOutput(s *mcpserver.McpServer) McpServerOutput {
+	headers := make([]McpServerHeaderOutput, len(s.Headers))
+	for i, hdr := range s.Headers {
+		headers[i] = McpServerHeaderOutput{Name: hdr.Name, Value: hdr.Value}
+	}
+	return McpServerOutput{
+		ID:        s.ID,
+		Name:      s.Name,
+		Transport: s.Transport,
+		URL:       s.URL,
+		Headers:   headers,
+		CreatedAt: s.CreatedAt,
+		UpdatedAt: s.UpdatedAt,
+	}
+}

--- a/internal/handlers/mcp_handler/playground_tools.go
+++ b/internal/handlers/mcp_handler/playground_tools.go
@@ -1,0 +1,219 @@
+package mcphandler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/DEEJ4Y/genkitkraft/internal/app/commands"
+	"github.com/DEEJ4Y/genkitkraft/internal/app/queries"
+	chatprovider "github.com/DEEJ4Y/genkitkraft/internal/ports/chat_provider"
+)
+
+// --- Input/Output types ---
+
+type ListPlaygroundSessionsInput struct {
+	AgentID string `json:"agent_id" jsonschema:"agent ID to list sessions for (required)"`
+}
+
+type PlaygroundSessionOutput struct {
+	ID        string    `json:"id"`
+	AgentID   string    `json:"agent_id"`
+	Title     string    `json:"title"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type ListPlaygroundSessionsOutput struct {
+	Sessions []PlaygroundSessionOutput `json:"sessions"`
+}
+
+type CreatePlaygroundSessionInput struct {
+	AgentID string `json:"agent_id" jsonschema:"agent ID (required)"`
+	Title   string `json:"title" jsonschema:"session title (required)"`
+}
+
+type DeletePlaygroundSessionInput struct {
+	ID      string `json:"id" jsonschema:"session ID to delete (required)"`
+	AgentID string `json:"agent_id" jsonschema:"agent ID (required)"`
+}
+
+type ListPlaygroundMessagesInput struct {
+	SessionID string `json:"session_id" jsonschema:"session ID (required)"`
+	AgentID   string `json:"agent_id" jsonschema:"agent ID (required)"`
+}
+
+type PlaygroundMessageOutput struct {
+	ID        string    `json:"id"`
+	SessionID string    `json:"session_id"`
+	Role      string    `json:"role"`
+	Content   string    `json:"content"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type ListPlaygroundMessagesOutput struct {
+	Messages []PlaygroundMessageOutput `json:"messages"`
+}
+
+type PlaygroundChatInput struct {
+	AgentID   string `json:"agent_id" jsonschema:"agent ID (required)"`
+	SessionID string `json:"session_id" jsonschema:"session ID (required)"`
+	Content   string `json:"content" jsonschema:"user message content (required)"`
+}
+
+type PlaygroundChatOutput struct {
+	Response string `json:"response" jsonschema:"assistant's response"`
+}
+
+// --- Tool registration ---
+
+func (h *Handler) registerPlaygroundTools(s *mcp.Server) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "playground_sessions_list",
+		Description: "List chat sessions for an agent.",
+	}, h.listPlaygroundSessions)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "playground_sessions_create",
+		Description: "Create a new chat session for an agent.",
+	}, h.createPlaygroundSession)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "playground_sessions_delete",
+		Description: "Delete a chat session.",
+	}, h.deletePlaygroundSession)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "playground_messages_list",
+		Description: "List all messages in a chat session.",
+	}, h.listPlaygroundMessages)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "playground_chat",
+		Description: "Send a message to an agent and get a response. The message and response are saved to the session history.",
+	}, h.playgroundChat)
+}
+
+// --- Tool handlers ---
+
+func (h *Handler) listPlaygroundSessions(ctx context.Context, _ *mcp.CallToolRequest, input ListPlaygroundSessionsInput) (*mcp.CallToolResult, ListPlaygroundSessionsOutput, error) {
+	result, err := h.playgroundApp.Queries.ListSessions.Execute(ctx, queries.ListPlaygroundSessionsParams{
+		AgentID: input.AgentID,
+	})
+	if err != nil {
+		return nil, ListPlaygroundSessionsOutput{}, fmt.Errorf("list sessions failed: %w", err)
+	}
+	sessions := make([]PlaygroundSessionOutput, len(result.Sessions))
+	for i, s := range result.Sessions {
+		sessions[i] = PlaygroundSessionOutput{
+			ID: s.ID, AgentID: s.AgentID, Title: s.Title,
+			CreatedAt: s.CreatedAt, UpdatedAt: s.UpdatedAt,
+		}
+	}
+	return nil, ListPlaygroundSessionsOutput{Sessions: sessions}, nil
+}
+
+func (h *Handler) createPlaygroundSession(ctx context.Context, _ *mcp.CallToolRequest, input CreatePlaygroundSessionInput) (*mcp.CallToolResult, PlaygroundSessionOutput, error) {
+	result, err := h.playgroundApp.Commands.CreateSession.Execute(ctx, commands.CreatePlaygroundSessionParams{
+		AgentID: input.AgentID,
+		Title:   input.Title,
+	})
+	if err != nil {
+		return nil, PlaygroundSessionOutput{}, fmt.Errorf("create session failed: %w", err)
+	}
+	s := result.Session
+	return nil, PlaygroundSessionOutput{
+		ID: s.ID, AgentID: s.AgentID, Title: s.Title,
+		CreatedAt: s.CreatedAt, UpdatedAt: s.UpdatedAt,
+	}, nil
+}
+
+func (h *Handler) deletePlaygroundSession(ctx context.Context, _ *mcp.CallToolRequest, input DeletePlaygroundSessionInput) (*mcp.CallToolResult, any, error) {
+	err := h.playgroundApp.Commands.DeleteSession.Execute(ctx, commands.DeletePlaygroundSessionParams{
+		ID:      input.ID,
+		AgentID: input.AgentID,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("delete session failed: %w", err)
+	}
+	return nil, map[string]string{"status": "deleted"}, nil
+}
+
+func (h *Handler) listPlaygroundMessages(ctx context.Context, _ *mcp.CallToolRequest, input ListPlaygroundMessagesInput) (*mcp.CallToolResult, ListPlaygroundMessagesOutput, error) {
+	result, err := h.playgroundApp.Queries.ListMessages.Execute(ctx, queries.ListPlaygroundMessagesParams{
+		SessionID: input.SessionID,
+		AgentID:   input.AgentID,
+	})
+	if err != nil {
+		return nil, ListPlaygroundMessagesOutput{}, fmt.Errorf("list messages failed: %w", err)
+	}
+	messages := make([]PlaygroundMessageOutput, len(result.Messages))
+	for i, m := range result.Messages {
+		messages[i] = PlaygroundMessageOutput{
+			ID: m.ID, SessionID: m.SessionID, Role: m.Role,
+			Content: m.Content, CreatedAt: m.CreatedAt,
+		}
+	}
+	return nil, ListPlaygroundMessagesOutput{Messages: messages}, nil
+}
+
+func (h *Handler) playgroundChat(ctx context.Context, _ *mcp.CallToolRequest, input PlaygroundChatInput) (*mcp.CallToolResult, PlaygroundChatOutput, error) {
+	// Save user message
+	_, err := h.playgroundApp.Commands.SaveMessage.Execute(ctx, commands.SavePlaygroundMessageParams{
+		SessionID: input.SessionID,
+		Role:      "user",
+		Content:   input.Content,
+	})
+	if err != nil {
+		return nil, PlaygroundChatOutput{}, fmt.Errorf("save user message failed: %w", err)
+	}
+
+	// Resolve agent config with tools
+	configResult, err := h.playgroundApp.Queries.ResolveConfig.Execute(ctx, queries.ResolvePlaygroundConfigParams{
+		AgentID:      input.AgentID,
+		IncludeTools: true,
+	})
+	if err != nil {
+		return nil, PlaygroundChatOutput{}, fmt.Errorf("resolve config failed: %w", err)
+	}
+
+	// Load conversation history
+	messagesResult, err := h.playgroundApp.Queries.ListMessages.Execute(ctx, queries.ListPlaygroundMessagesParams{
+		SessionID: input.SessionID,
+		AgentID:   input.AgentID,
+	})
+	if err != nil {
+		return nil, PlaygroundChatOutput{}, fmt.Errorf("list messages failed: %w", err)
+	}
+
+	// Build chat messages from history
+	chatMessages := make([]chatprovider.ChatMessage, 0, len(messagesResult.Messages))
+	for _, m := range messagesResult.Messages {
+		chatMessages = append(chatMessages, chatprovider.ChatMessage{
+			Role:    m.Role,
+			Content: m.Content,
+		})
+	}
+
+	chatReq := configResult.ChatRequest
+	chatReq.Messages = chatMessages
+
+	// Non-streaming chat
+	content, err := h.chatProvider.Chat(ctx, chatReq)
+	if err != nil {
+		return nil, PlaygroundChatOutput{}, fmt.Errorf("chat failed: %w", err)
+	}
+
+	// Save assistant response
+	if content != "" {
+		_, _ = h.playgroundApp.Commands.SaveMessage.Execute(ctx, commands.SavePlaygroundMessageParams{
+			SessionID: input.SessionID,
+			Role:      "assistant",
+			Content:   content,
+		})
+	}
+
+	return nil, PlaygroundChatOutput{Response: content}, nil
+}

--- a/internal/handlers/mcp_handler/prompt_registrations.go
+++ b/internal/handlers/mcp_handler/prompt_registrations.go
@@ -1,0 +1,28 @@
+package mcphandler
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+//go:embed prompts/create_agent.md
+var createAgentPromptContent string
+
+func (h *Handler) registerPrompts(s *mcp.Server) {
+	s.AddPrompt(&mcp.Prompt{
+		Name:        "create-agent",
+		Description: "Comprehensive guide for creating and configuring GenKitKraft agents via MCP tools. Includes tool reference, step-by-step workflow, and examples.",
+	}, func(ctx context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		return &mcp.GetPromptResult{
+			Description: "Step-by-step guide for creating GenKitKraft agents with all available MCP tools.",
+			Messages: []*mcp.PromptMessage{
+				{
+					Role:    "user",
+					Content: &mcp.TextContent{Text: createAgentPromptContent},
+				},
+			},
+		}, nil
+	})
+}

--- a/internal/handlers/mcp_handler/prompt_tools.go
+++ b/internal/handlers/mcp_handler/prompt_tools.go
@@ -1,0 +1,147 @@
+package mcphandler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/DEEJ4Y/genkitkraft/internal/app/commands"
+	"github.com/DEEJ4Y/genkitkraft/internal/app/queries"
+	"github.com/DEEJ4Y/genkitkraft/internal/domain/prompt"
+)
+
+// --- Input/Output types ---
+
+type ListPromptsInput struct {
+	Limit  int `json:"limit" jsonschema:"max number of prompts to return (default 20, max 100)"`
+	Offset int `json:"offset" jsonschema:"offset for pagination"`
+}
+
+type PromptOutput struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Content   string    `json:"content"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type ListPromptsOutput struct {
+	Prompts []PromptOutput `json:"prompts"`
+	Total   int            `json:"total"`
+}
+
+type GetPromptInput struct {
+	ID string `json:"id" jsonschema:"prompt ID"`
+}
+
+type CreatePromptInput struct {
+	Name    string `json:"name" jsonschema:"prompt name (required)"`
+	Content string `json:"content" jsonschema:"prompt content / system instructions (required)"`
+}
+
+type UpdatePromptInput struct {
+	ID      string  `json:"id" jsonschema:"prompt ID (required)"`
+	Name    *string `json:"name,omitempty" jsonschema:"new prompt name"`
+	Content *string `json:"content,omitempty" jsonschema:"new prompt content"`
+}
+
+type DeletePromptInput struct {
+	ID string `json:"id" jsonschema:"prompt ID to delete"`
+}
+
+// --- Tool registration ---
+
+func (h *Handler) registerPromptTools(s *mcp.Server) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "prompts_list",
+		Description: "List all system prompts with pagination.",
+	}, h.listPrompts)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "prompts_get",
+		Description: "Get a system prompt by ID.",
+	}, h.getPrompt)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "prompts_create",
+		Description: "Create a new system prompt.",
+	}, h.createPrompt)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "prompts_update",
+		Description: "Update an existing system prompt. Only provided fields are changed.",
+	}, h.updatePrompt)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "prompts_delete",
+		Description: "Delete a system prompt by ID.",
+	}, h.deletePrompt)
+}
+
+// --- Tool handlers ---
+
+func (h *Handler) listPrompts(ctx context.Context, _ *mcp.CallToolRequest, input ListPromptsInput) (*mcp.CallToolResult, ListPromptsOutput, error) {
+	result, err := h.promptApp.Queries.ListPrompts.Execute(ctx, queries.ListPromptsParams{
+		Limit:  input.Limit,
+		Offset: input.Offset,
+	})
+	if err != nil {
+		return nil, ListPromptsOutput{}, fmt.Errorf("list prompts failed: %w", err)
+	}
+	prompts := make([]PromptOutput, len(result.Prompts))
+	for i, p := range result.Prompts {
+		prompts[i] = toPromptOutput(p)
+	}
+	return nil, ListPromptsOutput{Prompts: prompts, Total: result.Total}, nil
+}
+
+func (h *Handler) getPrompt(ctx context.Context, _ *mcp.CallToolRequest, input GetPromptInput) (*mcp.CallToolResult, PromptOutput, error) {
+	result, err := h.promptApp.Queries.GetPrompt.Execute(ctx, queries.GetPromptParams{ID: input.ID})
+	if err != nil {
+		return nil, PromptOutput{}, fmt.Errorf("get prompt failed: %w", err)
+	}
+	return nil, toPromptOutput(result.Prompt), nil
+}
+
+func (h *Handler) createPrompt(ctx context.Context, _ *mcp.CallToolRequest, input CreatePromptInput) (*mcp.CallToolResult, PromptOutput, error) {
+	result, err := h.promptApp.Commands.CreatePrompt.Execute(ctx, commands.CreatePromptParams{
+		Name:    input.Name,
+		Content: input.Content,
+	})
+	if err != nil {
+		return nil, PromptOutput{}, fmt.Errorf("create prompt failed: %w", err)
+	}
+	return nil, toPromptOutput(result.Prompt), nil
+}
+
+func (h *Handler) updatePrompt(ctx context.Context, _ *mcp.CallToolRequest, input UpdatePromptInput) (*mcp.CallToolResult, PromptOutput, error) {
+	result, err := h.promptApp.Commands.UpdatePrompt.Execute(ctx, commands.UpdatePromptParams{
+		ID:      input.ID,
+		Name:    input.Name,
+		Content: input.Content,
+	})
+	if err != nil {
+		return nil, PromptOutput{}, fmt.Errorf("update prompt failed: %w", err)
+	}
+	return nil, toPromptOutput(result.Prompt), nil
+}
+
+func (h *Handler) deletePrompt(ctx context.Context, _ *mcp.CallToolRequest, input DeletePromptInput) (*mcp.CallToolResult, any, error) {
+	err := h.promptApp.Commands.DeletePrompt.Execute(ctx, commands.DeletePromptParams{ID: input.ID})
+	if err != nil {
+		return nil, nil, fmt.Errorf("delete prompt failed: %w", err)
+	}
+	return nil, map[string]string{"status": "deleted"}, nil
+}
+
+func toPromptOutput(p *prompt.Prompt) PromptOutput {
+	return PromptOutput{
+		ID:        p.ID,
+		Name:      p.Name,
+		Content:   p.Content,
+		CreatedAt: p.CreatedAt,
+		UpdatedAt: p.UpdatedAt,
+	}
+}

--- a/internal/handlers/mcp_handler/prompts/create_agent.md
+++ b/internal/handlers/mcp_handler/prompts/create_agent.md
@@ -1,0 +1,255 @@
+# GenKitKraft Agent Creation Guide
+
+You are connected to a GenKitKraft MCP server. GenKitKraft is a self-hostable platform for configuring and running LLM agents. Through these MCP tools, you can create fully configured AI agents, assign them tools, and chat with them — all programmatically.
+
+## Available Tools
+
+### Provider Management
+| Tool | Description |
+|------|-------------|
+| `provider_types_list` | List supported LLM provider types (openai, google_ai, anthropic, etc.) and their requirements |
+| `providers_create` | Register an LLM provider with API key and configuration |
+| `providers_list` | List all configured providers |
+| `providers_get` | Get details of a specific provider |
+| `providers_update` | Update a provider's config (name, API key, base URL, enabled status) |
+| `providers_delete` | Delete a provider |
+| `providers_test` | Test connectivity to a provider |
+
+### System Prompts
+| Tool | Description |
+|------|-------------|
+| `prompts_create` | Create a system prompt (name + content) |
+| `prompts_list` | List all prompts |
+| `prompts_get` | Get a prompt by ID |
+| `prompts_update` | Update a prompt's name or content |
+| `prompts_delete` | Delete a prompt |
+
+### Agent Management
+| Tool | Description |
+|------|-------------|
+| `agents_create` | Create an agent (requires provider_id, model_id; optionally system_prompt_id and sampling params) |
+| `agents_list` | List all agents |
+| `agents_get` | Get agent details |
+| `agents_update` | Update agent configuration |
+| `agents_delete` | Delete an agent |
+
+### Agent Tool Configuration
+| Tool | Description |
+|------|-------------|
+| `agent_tools_get` | Get which tools (HTTP tools and MCP servers) are assigned to an agent |
+| `agent_tools_update` | Assign HTTP tools and MCP server tools to an agent (replaces entire config) |
+
+### HTTP Tools (custom API tools for agents)
+| Tool | Description |
+|------|-------------|
+| `http_tools_create` | Create an HTTP tool (name, description, method, URL, headers, body template, input schema) |
+| `http_tools_list` | List all HTTP tools |
+| `http_tools_get` | Get an HTTP tool by ID |
+| `http_tools_update` | Update an HTTP tool |
+| `http_tools_delete` | Delete an HTTP tool |
+
+### MCP Servers (external MCP servers for agents)
+| Tool | Description |
+|------|-------------|
+| `mcp_servers_create` | Register an external MCP server (name, transport, URL, headers) |
+| `mcp_servers_list` | List all registered MCP servers |
+| `mcp_servers_get` | Get an MCP server by ID |
+| `mcp_servers_update` | Update an MCP server |
+| `mcp_servers_delete` | Delete an MCP server |
+| `mcp_servers_list_tools` | List tools exposed by an MCP server (discover what tools it provides) |
+
+### Playground (chat with agents)
+| Tool | Description |
+|------|-------------|
+| `playground_sessions_create` | Create a new chat session for an agent |
+| `playground_sessions_list` | List chat sessions for an agent |
+| `playground_sessions_delete` | Delete a chat session |
+| `playground_messages_list` | List messages in a chat session |
+| `playground_chat` | Send a message to an agent and get a response |
+
+### Health
+| Tool | Description |
+|------|-------------|
+| `health_liveness` | Check if the server is alive |
+| `health_readiness` | Check if the server is ready to serve requests |
+
+---
+
+## Step-by-Step: Create an Agent
+
+Follow these steps in order. Each step depends on outputs from the previous one.
+
+### Step 1: Check available provider types
+
+```
+Tool: provider_types_list
+Input: {}
+```
+
+This returns supported provider types (e.g., `openai`, `google_ai`, `anthropic`) with their requirements (API key, base URL, etc.). Use this to know what `provider_type` to use in the next step.
+
+### Step 2: Create a provider
+
+```
+Tool: providers_create
+Input: {
+  "name": "My OpenAI Provider",
+  "provider_type": "openai",
+  "api_key": "<user's API key>"
+}
+```
+
+**Save the returned `id`** — you'll need it as `provider_id` when creating the agent.
+
+For providers with custom endpoints (e.g., Azure OpenAI, local models), also set `base_url`.
+
+You can verify connectivity with:
+```
+Tool: providers_test
+Input: { "id": "<provider_id>" }
+```
+
+### Step 3: Create a system prompt (optional but recommended)
+
+```
+Tool: prompts_create
+Input: {
+  "name": "Customer Support Agent",
+  "content": "You are a helpful customer support agent. Be polite, concise, and accurate. If you don't know the answer, say so honestly."
+}
+```
+
+**Save the returned `id`** — you'll need it as `system_prompt_id` when creating the agent.
+
+### Step 4: Create the agent
+
+```
+Tool: agents_create
+Input: {
+  "name": "Support Bot",
+  "provider_id": "<provider_id from step 2>",
+  "model_id": "gpt-4o",
+  "system_prompt_id": "<prompt_id from step 3>"
+}
+```
+
+**Save the returned `id`** — this is your agent ID.
+
+Optional parameters:
+- `temperature_enabled`: true/false — enable temperature sampling
+- `temperature`: 0.0 to 2.0 — controls randomness
+- `top_p_enabled`: true/false — enable top-p (nucleus) sampling
+- `top_p`: 0.0 to 1.0 — cumulative probability threshold
+- `top_k_enabled`: true/false — enable top-k sampling
+- `top_k`: integer — number of top tokens to consider
+
+### Step 5: Assign tools to the agent (optional)
+
+If you want the agent to use external tools (HTTP APIs or MCP servers), configure them first:
+
+**Create HTTP tools:**
+```
+Tool: http_tools_create
+Input: {
+  "name": "Weather API",
+  "description": "Get current weather for a city",
+  "method": "GET",
+  "url": "https://api.weather.com/current?city={{city}}",
+  "headers": [{"name": "Authorization", "value": "Bearer <key>"}],
+  "input_schema": "{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}"
+}
+```
+
+**Register external MCP servers:**
+```
+Tool: mcp_servers_create
+Input: {
+  "name": "My MCP Server",
+  "transport": "streamable_http",
+  "url": "http://localhost:8080/mcp"
+}
+```
+
+Then discover MCP server tools:
+```
+Tool: mcp_servers_list_tools
+Input: { "id": "<mcp_server_id>" }
+```
+
+**Assign tools to the agent:**
+```
+Tool: agent_tools_update
+Input: {
+  "agent_id": "<agent_id from step 4>",
+  "http_tool_ids": ["<http_tool_id>"],
+  "mcp_servers": [
+    {
+      "mcp_server_id": "<mcp_server_id>",
+      "tool_names": ["tool_name_1", "tool_name_2"]
+    }
+  ]
+}
+```
+
+### Step 6: Chat with the agent
+
+**Create a chat session:**
+```
+Tool: playground_sessions_create
+Input: {
+  "agent_id": "<agent_id>",
+  "title": "Test Session"
+}
+```
+
+**Send a message:**
+```
+Tool: playground_chat
+Input: {
+  "agent_id": "<agent_id>",
+  "session_id": "<session_id>",
+  "message": "Hello! Can you help me?"
+}
+```
+
+The response includes the agent's reply. Continue the conversation by sending more messages to the same session.
+
+**View conversation history:**
+```
+Tool: playground_messages_list
+Input: {
+  "agent_id": "<agent_id>",
+  "session_id": "<session_id>"
+}
+```
+
+---
+
+## Quick Reference: Required ID Chain
+
+```
+provider_types_list → pick a type
+     ↓
+providers_create (type + API key) → provider_id
+     ↓
+prompts_create (name + content) → prompt_id (optional)
+     ↓
+agents_create (provider_id + model_id + prompt_id) → agent_id
+     ↓
+http_tools_create / mcp_servers_create → tool IDs (optional)
+     ↓
+agent_tools_update (agent_id + tool IDs) (optional)
+     ↓
+playground_sessions_create (agent_id) → session_id
+     ↓
+playground_chat (agent_id + session_id + message) → agent response
+```
+
+## Tips
+
+- **IDs are UUIDs**: All created resources return a UUID `id`. Always use the exact ID from the creation response.
+- **Pagination**: List operations accept `limit` and `offset` parameters. Defaults: limit=20, max=100.
+- **Updating vs replacing**: `agents_update` and similar tools do partial updates — only fields you include are changed. `agent_tools_update` is an exception — it replaces the entire tool configuration.
+- **Model IDs**: The `model_id` depends on the provider type. Common examples: `gpt-4o`, `gpt-4o-mini` (OpenAI), `gemini-2.0-flash` (Google AI), `claude-sonnet-4-20250514` (Anthropic).
+- **Testing providers**: Always test a provider after creation to verify the API key and configuration are correct.
+- **Multiple agents**: You can reuse the same provider and prompt across multiple agents. Create once, reference by ID.

--- a/internal/handlers/mcp_handler/provider_tools.go
+++ b/internal/handlers/mcp_handler/provider_tools.go
@@ -1,0 +1,232 @@
+package mcphandler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/DEEJ4Y/genkitkraft/internal/app/commands"
+	"github.com/DEEJ4Y/genkitkraft/internal/app/queries"
+	"github.com/DEEJ4Y/genkitkraft/internal/domain/provider"
+)
+
+// --- Input/Output types ---
+
+type ListProvidersInput struct{}
+
+type ProviderOutput struct {
+	ID           string            `json:"id"`
+	Name         string            `json:"name"`
+	ProviderType string            `json:"provider_type"`
+	APIKey       string            `json:"api_key,omitempty"`
+	BaseURL      string            `json:"base_url,omitempty"`
+	Config       map[string]string `json:"config,omitempty"`
+	Enabled      bool              `json:"enabled"`
+	CreatedAt    time.Time         `json:"created_at"`
+	UpdatedAt    time.Time         `json:"updated_at"`
+}
+
+type ListProvidersOutput struct {
+	Providers []ProviderOutput `json:"providers"`
+}
+
+type GetProviderInput struct {
+	ID string `json:"id" jsonschema:"provider ID"`
+}
+
+type CreateProviderInput struct {
+	Name         string            `json:"name" jsonschema:"provider name (required)"`
+	ProviderType string            `json:"provider_type" jsonschema:"provider type, e.g. openai, google_ai, anthropic (required)"`
+	APIKey       *string           `json:"api_key,omitempty" jsonschema:"API key for the provider"`
+	BaseURL      string            `json:"base_url,omitempty" jsonschema:"custom base URL"`
+	Config       map[string]string `json:"config,omitempty" jsonschema:"provider-specific config fields"`
+}
+
+type UpdateProviderInput struct {
+	ID      string             `json:"id" jsonschema:"provider ID (required)"`
+	Name    *string            `json:"name,omitempty" jsonschema:"new provider name"`
+	APIKey  *string            `json:"api_key,omitempty" jsonschema:"new API key"`
+	BaseURL *string            `json:"base_url,omitempty" jsonschema:"new base URL"`
+	Config  *map[string]string `json:"config,omitempty" jsonschema:"new config fields"`
+	Enabled *bool              `json:"enabled,omitempty" jsonschema:"enable or disable the provider"`
+}
+
+type DeleteProviderInput struct {
+	ID string `json:"id" jsonschema:"provider ID to delete"`
+}
+
+type TestProviderInput struct {
+	ID string `json:"id" jsonschema:"provider ID to test connectivity"`
+}
+
+type TestProviderOutput struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}
+
+type ListProviderTypesInput struct{}
+
+type ProviderTypeOutput struct {
+	Type            string `json:"type"`
+	DisplayName     string `json:"display_name"`
+	RequiresAPIKey  bool   `json:"requires_api_key"`
+	RequiresBaseURL bool   `json:"requires_base_url"`
+	ModelPrefix     string `json:"model_prefix,omitempty"`
+	BaseURLDefault  string `json:"base_url_default,omitempty"`
+	ComingSoon      bool   `json:"coming_soon,omitempty"`
+}
+
+type ListProviderTypesOutput struct {
+	ProviderTypes []ProviderTypeOutput `json:"provider_types"`
+}
+
+// --- Tool registration ---
+
+func (h *Handler) registerProviderTools(s *mcp.Server) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "providers_list",
+		Description: "List all configured LLM providers.",
+	}, h.listProviders)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "providers_get",
+		Description: "Get an LLM provider by ID.",
+	}, h.getProvider)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "providers_create",
+		Description: "Create a new LLM provider configuration.",
+	}, h.createProvider)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "providers_update",
+		Description: "Update an existing LLM provider. Only provided fields are changed.",
+	}, h.updateProvider)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "providers_delete",
+		Description: "Delete an LLM provider by ID.",
+	}, h.deleteProvider)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "providers_test",
+		Description: "Test connectivity to an LLM provider.",
+	}, h.testProvider)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "provider_types_list",
+		Description: "List all supported LLM provider types and their metadata.",
+	}, h.listProviderTypes)
+}
+
+// --- Tool handlers ---
+
+func (h *Handler) listProviders(ctx context.Context, _ *mcp.CallToolRequest, _ ListProvidersInput) (*mcp.CallToolResult, ListProvidersOutput, error) {
+	result, err := h.providerApp.Queries.ListProviders.Execute(ctx, queries.ListProvidersParams{})
+	if err != nil {
+		return nil, ListProvidersOutput{}, fmt.Errorf("list providers failed: %w", err)
+	}
+	providers := make([]ProviderOutput, len(result.Providers))
+	for i, p := range result.Providers {
+		providers[i] = toProviderOutput(p)
+	}
+	return nil, ListProvidersOutput{Providers: providers}, nil
+}
+
+func (h *Handler) getProvider(ctx context.Context, _ *mcp.CallToolRequest, input GetProviderInput) (*mcp.CallToolResult, ProviderOutput, error) {
+	result, err := h.providerApp.Queries.GetProvider.Execute(ctx, queries.GetProviderParams{ID: input.ID})
+	if err != nil {
+		return nil, ProviderOutput{}, fmt.Errorf("get provider failed: %w", err)
+	}
+	return nil, toProviderOutput(result.Provider), nil
+}
+
+func (h *Handler) createProvider(ctx context.Context, _ *mcp.CallToolRequest, input CreateProviderInput) (*mcp.CallToolResult, ProviderOutput, error) {
+	result, err := h.providerApp.Commands.CreateProvider.Execute(ctx, commands.CreateProviderParams{
+		Name:         input.Name,
+		ProviderType: provider.ProviderType(input.ProviderType),
+		APIKey:       input.APIKey,
+		BaseURL:      input.BaseURL,
+		Config:       input.Config,
+	})
+	if err != nil {
+		return nil, ProviderOutput{}, fmt.Errorf("create provider failed: %w", err)
+	}
+	return nil, toProviderOutput(result.Provider), nil
+}
+
+func (h *Handler) updateProvider(ctx context.Context, _ *mcp.CallToolRequest, input UpdateProviderInput) (*mcp.CallToolResult, ProviderOutput, error) {
+	result, err := h.providerApp.Commands.UpdateProvider.Execute(ctx, commands.UpdateProviderParams{
+		ID:      input.ID,
+		Name:    input.Name,
+		APIKey:  input.APIKey,
+		BaseURL: input.BaseURL,
+		Config:  input.Config,
+		Enabled: input.Enabled,
+	})
+	if err != nil {
+		return nil, ProviderOutput{}, fmt.Errorf("update provider failed: %w", err)
+	}
+	return nil, toProviderOutput(result.Provider), nil
+}
+
+func (h *Handler) deleteProvider(ctx context.Context, _ *mcp.CallToolRequest, input DeleteProviderInput) (*mcp.CallToolResult, any, error) {
+	err := h.providerApp.Commands.DeleteProvider.Execute(ctx, commands.DeleteProviderParams{ID: input.ID})
+	if err != nil {
+		return nil, nil, fmt.Errorf("delete provider failed: %w", err)
+	}
+	return nil, map[string]string{"status": "deleted"}, nil
+}
+
+func (h *Handler) testProvider(ctx context.Context, _ *mcp.CallToolRequest, input TestProviderInput) (*mcp.CallToolResult, TestProviderOutput, error) {
+	result, err := h.providerApp.Commands.TestProvider.Execute(ctx, commands.TestProviderParams{ID: input.ID})
+	if err != nil {
+		return nil, TestProviderOutput{}, fmt.Errorf("test provider failed: %w", err)
+	}
+	return nil, TestProviderOutput{Success: result.Success, Message: result.Message}, nil
+}
+
+func (h *Handler) listProviderTypes(ctx context.Context, _ *mcp.CallToolRequest, _ ListProviderTypesInput) (*mcp.CallToolResult, ListProviderTypesOutput, error) {
+	result, err := h.providerApp.Queries.ListProviderTypes.Execute(ctx, queries.ListProviderTypesParams{})
+	if err != nil {
+		return nil, ListProviderTypesOutput{}, fmt.Errorf("list provider types failed: %w", err)
+	}
+	types := make([]ProviderTypeOutput, len(result.ProviderTypes))
+	for i, pt := range result.ProviderTypes {
+		types[i] = ProviderTypeOutput{
+			Type:            string(pt.Type),
+			DisplayName:     pt.DisplayName,
+			RequiresAPIKey:  pt.RequiresAPIKey,
+			RequiresBaseURL: pt.RequiresBaseURL,
+			ModelPrefix:     pt.ModelPrefix,
+			BaseURLDefault:  pt.BaseURLDefault,
+			ComingSoon:      pt.ComingSoon,
+		}
+	}
+	return nil, ListProviderTypesOutput{ProviderTypes: types}, nil
+}
+
+func toProviderOutput(p *provider.Provider) ProviderOutput {
+	out := ProviderOutput{
+		ID:           p.ID,
+		Name:         p.Name,
+		ProviderType: string(p.ProviderType),
+		BaseURL:      p.BaseURL,
+		Enabled:      p.Enabled,
+		CreatedAt:    p.CreatedAt,
+		UpdatedAt:    p.UpdatedAt,
+	}
+	if masked := p.MaskedAPIKey(); masked != nil {
+		out.APIKey = *masked
+	}
+	if len(p.RawConfig) > 0 && string(p.RawConfig) != "{}" {
+		var configMap map[string]string
+		if err := json.Unmarshal(p.RawConfig, &configMap); err == nil && len(configMap) > 0 {
+			out.Config = configMap
+		}
+	}
+	return out
+}

--- a/internal/services/server.go
+++ b/internal/services/server.go
@@ -35,6 +35,7 @@ import (
 	domainauth "github.com/DEEJ4Y/genkitkraft/internal/domain/auth"
 	httphandler "github.com/DEEJ4Y/genkitkraft/internal/handlers/http_handler"
 	"github.com/DEEJ4Y/genkitkraft/internal/handlers/http_handler/interceptors"
+	mcphandler "github.com/DEEJ4Y/genkitkraft/internal/handlers/mcp_handler"
 	chatprovider "github.com/DEEJ4Y/genkitkraft/internal/ports/chat_provider"
 	"github.com/DEEJ4Y/genkitkraft/internal/ports/hasher"
 	"github.com/DEEJ4Y/genkitkraft/internal/ports/session"
@@ -327,6 +328,14 @@ func (s *Server) Start() error {
 
 	// SPA fallback: serve embedded UI or fallback to index.html
 	mux.HandleFunc("/", spaHandler())
+
+	// Mount MCP server at /mcp
+	mcpH := mcphandler.NewHandler(
+		s.authApp, s.providerApp, s.promptApp, s.agentApp,
+		s.playgroundApp, s.httpToolApp, s.mcpServerApp, s.agentToolApp,
+		s.chatProvider, mcpDiscovery, s.cfg.Auth,
+	)
+	mux.Handle("/mcp", mcpH.HTTPHandler())
 
 	// Wrap with auth middleware
 	handler := interceptors.DeployAuthMiddleware(s.cfg.Deploy.APIKeys)(interceptors.AuthMiddleware(s.authApp)(mux))

--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -44,6 +44,7 @@ AUTH_CREDENTIALS=admin:changeme,readonly:viewer123
 
 - When set: all UI and API access requires authentication
 - When unset: authentication is disabled entirely
+- Also controls authentication for the [MCP endpoint](/docs/guides/mcp-quickstart) — when set, the MCP server requires HTTP Basic Auth with the same credentials
 - See [Authentication](./authentication) for more details
 
 ### `PUBLIC_API_KEY`

--- a/website/docs/guides/mcp-agent-creation-guide.md
+++ b/website/docs/guides/mcp-agent-creation-guide.md
@@ -1,0 +1,132 @@
+# Creating Agents via MCP
+
+This guide explains how to create and configure GenKitKraft agents using the MCP (Model Context Protocol) tools. You can follow these steps manually through any MCP client, or paste the prompt below into an LLM connected to GenKitKraft's MCP server and let it handle everything.
+
+## Prerequisites
+
+- GenKitKraft running (see [Docker setup](/docs/guides/docker))
+- MCP client connected to GenKitKraft (see [MCP Quickstart](/docs/guides/mcp-quickstart))
+
+## The `create-agent` Prompt
+
+GenKitKraft's MCP server includes a built-in **`create-agent` prompt** that provides the LLM with a comprehensive guide to all available tools and the correct order to use them. MCP clients that support server-side prompts (like Claude Desktop) can load this prompt automatically.
+
+If your MCP client doesn't support prompts, you can copy the guide below and paste it into your LLM's context.
+
+## Agent Creation Workflow
+
+Follow these steps in order. Each step produces an ID needed by the next.
+
+```
+provider_types_list → pick a provider type
+        ↓
+providers_create → provider_id
+        ↓
+prompts_create → prompt_id (optional)
+        ↓
+agents_create → agent_id
+        ↓
+[http_tools_create / mcp_servers_create → tool IDs] (optional)
+        ↓
+[agent_tools_update → assign tools to agent] (optional)
+        ↓
+playground_sessions_create → session_id
+        ↓
+playground_chat → agent response
+```
+
+### 1. List provider types
+
+Call `provider_types_list` to see supported LLM providers (openai, google_ai, anthropic, etc.) and what each one requires.
+
+### 2. Create a provider
+
+Call `providers_create` with:
+- `name` — a display name
+- `provider_type` — from step 1 (e.g., `openai`)
+- `api_key` — your API key for the provider
+
+Optionally set `base_url` for custom endpoints (Azure, local models).
+
+Save the returned **`id`** as your `provider_id`.
+
+Use `providers_test` with the provider ID to verify connectivity.
+
+### 3. Create a system prompt (optional)
+
+Call `prompts_create` with:
+- `name` — prompt name
+- `content` — the system instructions for the agent
+
+Save the returned **`id`** as your `prompt_id`.
+
+### 4. Create the agent
+
+Call `agents_create` with:
+- `name` — agent name
+- `provider_id` — from step 2
+- `model_id` — the model to use (e.g., `gpt-4o`, `gemini-2.0-flash`, `claude-sonnet-4-20250514`)
+- `system_prompt_id` — from step 3 (optional)
+
+Save the returned **`id`** as your `agent_id`.
+
+### 5. Assign tools (optional)
+
+If you want your agent to call external APIs or MCP servers:
+
+1. Create HTTP tools with `http_tools_create` and/or register external MCP servers with `mcp_servers_create`
+2. Discover MCP server tools with `mcp_servers_list_tools`
+3. Assign them to the agent with `agent_tools_update`
+
+### 6. Chat with the agent
+
+1. Create a session: `playground_sessions_create` with `agent_id` and a `title`
+2. Send messages: `playground_chat` with `agent_id`, `session_id`, and `message`
+3. View history: `playground_messages_list` with `agent_id` and `session_id`
+
+---
+
+## Copyable Prompt for Any LLM
+
+If your LLM is connected to GenKitKraft's MCP server but your client doesn't support MCP prompts, copy and paste the following into your conversation:
+
+<details>
+<summary>Click to expand the full prompt</summary>
+
+```
+You are connected to a GenKitKraft MCP server. GenKitKraft is a self-hostable platform for configuring and running LLM agents. Through these MCP tools, you can create fully configured AI agents, assign them tools, and chat with them — all programmatically.
+
+Available tools by category:
+
+PROVIDERS: provider_types_list, providers_create, providers_list, providers_get, providers_update, providers_delete, providers_test
+PROMPTS: prompts_create, prompts_list, prompts_get, prompts_update, prompts_delete
+AGENTS: agents_create, agents_list, agents_get, agents_update, agents_delete
+AGENT TOOLS: agent_tools_get, agent_tools_update
+HTTP TOOLS: http_tools_create, http_tools_list, http_tools_get, http_tools_update, http_tools_delete
+MCP SERVERS: mcp_servers_create, mcp_servers_list, mcp_servers_get, mcp_servers_update, mcp_servers_delete, mcp_servers_list_tools
+PLAYGROUND: playground_sessions_create, playground_sessions_list, playground_sessions_delete, playground_messages_list, playground_chat
+HEALTH: health_liveness, health_readiness
+
+To create a new agent, follow this order:
+1. provider_types_list — see available provider types
+2. providers_create — register an LLM provider (name, provider_type, api_key). Save the returned id.
+3. providers_test — verify the provider works
+4. prompts_create — create a system prompt (name, content). Save the returned id. (optional)
+5. agents_create — create the agent (name, provider_id, model_id, system_prompt_id). Save the returned id.
+6. http_tools_create / mcp_servers_create — create tools for the agent (optional)
+7. agent_tools_update — assign tools to the agent (optional)
+8. playground_sessions_create — start a chat session (agent_id, title). Save the returned id.
+9. playground_chat — send a message (agent_id, session_id, message)
+
+Key notes:
+- All IDs are UUIDs returned by create operations. Always use the exact ID from the response.
+- Model IDs depend on the provider: gpt-4o (OpenAI), gemini-2.0-flash (Google AI), claude-sonnet-4-20250514 (Anthropic).
+- agent_tools_update replaces the entire tool configuration — include all tools you want assigned.
+- List operations accept limit (default 20, max 100) and offset for pagination.
+```
+
+</details>
+
+## Complete Tool Reference
+
+See the [MCP Quickstart](/docs/guides/mcp-quickstart#available-tools) for a full table of all available tools with descriptions.

--- a/website/docs/guides/mcp-quickstart.md
+++ b/website/docs/guides/mcp-quickstart.md
@@ -170,6 +170,12 @@ Using any MCP client, you can create a fully configured agent in a few tool call
 5. **`playground_sessions_create`** — start a chat session
 6. **`playground_chat`** — chat with your agent
 
+For a detailed walkthrough with examples and input schemas, see the [Agent Creation Guide](/docs/guides/mcp-agent-creation-guide).
+
+## Built-in Prompts
+
+The MCP server includes a **`create-agent`** prompt that provides the LLM with a comprehensive guide to all available tools and the correct workflow for creating agents. MCP clients that support server-side prompts (like Claude Desktop) can load this prompt automatically to give the LLM full context.
+
 ## Troubleshooting
 
 **401 Unauthorized**: `AUTH_CREDENTIALS` is set but your client isn't sending the correct Basic Auth header. Double-check the base64-encoded `username:password`.

--- a/website/docs/guides/mcp-quickstart.md
+++ b/website/docs/guides/mcp-quickstart.md
@@ -1,0 +1,179 @@
+---
+sidebar_position: 6
+---
+
+# MCP Quickstart
+
+GenKitKraft exposes all of its management APIs as [MCP](https://modelcontextprotocol.io/) tools. This lets you manage agents, providers, prompts, tools, and even chat — directly from any MCP-compatible client (Claude Desktop, Cursor, custom agents, etc.).
+
+## Prerequisites
+
+- GenKitKraft running (see [Getting Started](/docs/getting-started/docker))
+
+## Endpoint
+
+The MCP server is available at:
+
+```
+http://<host>:<port>/mcp
+```
+
+Default: `http://localhost:8080/mcp`
+
+It uses the **Streamable HTTP** transport.
+
+## Authentication
+
+- If [`AUTH_CREDENTIALS`](/docs/configuration/environment-variables#auth_credentials) is set, the MCP endpoint requires **HTTP Basic Auth** with the same username and password.
+- If `AUTH_CREDENTIALS` is not set, the MCP endpoint is open (no auth).
+
+## Connecting from Claude Desktop
+
+Add GenKitKraft to your Claude Desktop MCP config (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "genkitkraft": {
+      "url": "http://localhost:8080/mcp"
+    }
+  }
+}
+```
+
+If authentication is enabled, add an `Authorization` header:
+
+```json
+{
+  "mcpServers": {
+    "genkitkraft": {
+      "url": "http://localhost:8080/mcp",
+      "headers": {
+        "Authorization": "Basic <base64-encoded username:password>"
+      }
+    }
+  }
+}
+```
+
+:::tip
+Generate the base64 value with: `echo -n "admin:changeme" | base64`
+:::
+
+## Connecting from Cursor
+
+In Cursor settings, add an MCP server with:
+
+- **Type**: Streamable HTTP
+- **URL**: `http://localhost:8080/mcp`
+
+If auth is required, configure the Basic Auth header as above.
+
+## Available Tools
+
+Once connected, your MCP client will discover all available tools automatically. Here's a summary:
+
+### Agents
+
+| Tool | Description |
+|------|-------------|
+| `agents_list` | List all agents with pagination |
+| `agents_get` | Get an agent by ID |
+| `agents_create` | Create a new agent |
+| `agents_update` | Update an agent |
+| `agents_delete` | Delete an agent |
+
+### Agent Tool Config
+
+| Tool | Description |
+|------|-------------|
+| `agent_tools_get` | Get which tools are assigned to an agent |
+| `agent_tools_update` | Update tool assignments for an agent |
+
+### Prompts
+
+| Tool | Description |
+|------|-------------|
+| `prompts_list` | List all system prompts |
+| `prompts_get` | Get a prompt by ID |
+| `prompts_create` | Create a new system prompt |
+| `prompts_update` | Update a prompt |
+| `prompts_delete` | Delete a prompt |
+
+### Providers
+
+| Tool | Description |
+|------|-------------|
+| `providers_list` | List all LLM providers |
+| `providers_get` | Get a provider by ID |
+| `providers_create` | Create a new provider |
+| `providers_update` | Update a provider |
+| `providers_delete` | Delete a provider |
+| `providers_test` | Test provider connectivity |
+| `provider_types_list` | List supported provider types |
+
+### HTTP Tools
+
+| Tool | Description |
+|------|-------------|
+| `http_tools_list` | List all HTTP tools |
+| `http_tools_get` | Get an HTTP tool by ID |
+| `http_tools_create` | Create a new HTTP tool |
+| `http_tools_update` | Update an HTTP tool |
+| `http_tools_delete` | Delete an HTTP tool |
+
+### MCP Servers
+
+| Tool | Description |
+|------|-------------|
+| `mcp_servers_list` | List all registered MCP servers |
+| `mcp_servers_get` | Get an MCP server by ID |
+| `mcp_servers_create` | Register a new MCP server |
+| `mcp_servers_update` | Update an MCP server |
+| `mcp_servers_delete` | Delete an MCP server |
+| `mcp_servers_list_tools` | Discover tools from an MCP server |
+
+### Playground
+
+| Tool | Description |
+|------|-------------|
+| `playground_sessions_list` | List chat sessions for an agent |
+| `playground_sessions_create` | Create a new chat session |
+| `playground_sessions_delete` | Delete a chat session |
+| `playground_messages_list` | List messages in a session |
+| `playground_chat` | Send a message and get a response |
+
+### Auth
+
+| Tool | Description |
+|------|-------------|
+| `auth_login` | Log in with username/password |
+| `auth_logout` | Log out (invalidate session) |
+| `auth_get_me` | Get current user info |
+| `auth_get_status` | Check if auth is required |
+
+### Health
+
+| Tool | Description |
+|------|-------------|
+| `health_liveness` | Liveness check |
+| `health_readiness` | Readiness check |
+
+## Example: Set up a new agent via MCP
+
+Using any MCP client, you can create a fully configured agent in a few tool calls:
+
+1. **`provider_types_list`** — see available provider types
+2. **`providers_create`** — configure an LLM provider (e.g., OpenAI with your API key)
+3. **`prompts_create`** — create a system prompt
+4. **`agents_create`** — create an agent using the provider and prompt
+5. **`playground_sessions_create`** — start a chat session
+6. **`playground_chat`** — chat with your agent
+
+## Troubleshooting
+
+**401 Unauthorized**: `AUTH_CREDENTIALS` is set but your client isn't sending the correct Basic Auth header. Double-check the base64-encoded `username:password`.
+
+**Connection refused**: Make sure GenKitKraft is running and the URL/port are correct. If running in Docker, ensure the port is mapped.
+
+**Empty tool list**: The MCP client may not support the Streamable HTTP transport. Check your client's MCP transport support.


### PR DESCRIPTION
## Summary

Adds a full MCP (Model Context Protocol) server to GenKitKraft, exposing all management APIs as MCP tools. This enables users to build agents programmatically using any MCP client (Claude Desktop, Cursor, custom agents).

## What's included

### MCP Server (`/mcp` endpoint)
- **~36 MCP tools** covering all management APIs: providers, agents, prompts, HTTP tools, MCP servers, playground (chat), auth, and health
- **StreamableHTTP transport** via the official [MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk) v1.5.0
- **Optional basic auth** — if `AUTH_CREDENTIALS` is set, MCP endpoint requires HTTP Basic Auth; otherwise open access

### Built-in `create-agent` prompt
- Server-side MCP prompt registered via `Server.AddPrompt()` that provides LLMs with a comprehensive guide to all tools and the correct workflow
- Covers tool reference, step-by-step agent creation, input schemas, and tips
- MCP clients that support prompts load this automatically

### Documentation
- **MCP Quickstart guide** (`website/docs/guides/mcp-quickstart.md`) — connection setup for Claude Desktop/Cursor, tool reference, troubleshooting
- **Agent Creation Guide** (`website/docs/guides/mcp-agent-creation-guide.md`) — detailed workflow + copyable prompt for any LLM
- **README** — prominent MCP section with config example
- **Env vars doc** — updated to note MCP auth behavior

## Files changed

### New files
- `internal/handlers/mcp_handler/` — 12 files (handler, auth middleware, tool registrations by domain, prompt registration)
- `internal/handlers/mcp_handler/prompts/create_agent.md` — embedded prompt content
- `website/docs/guides/mcp-quickstart.md`
- `website/docs/guides/mcp-agent-creation-guide.md`

### Modified files
- `internal/services/server.go` — wires MCP handler at `/mcp`
- `go.mod` / `go.sum` — MCP Go SDK dependency
- `README.md` — MCP section
- `website/docs/configuration/environment-variables.md` — MCP auth note

## Testing

- `go build ./...` ✅
- `go vet ./...` ✅
