### PR TITLE
feat: scoped in-memory cache port for sessions, rate limiting, and web fetch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/oapi-codegen/oapi-codegen/v2 v2.4.1
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/openai/openai-go v1.8.2
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pressly/goose/v3 v3.24.1
 	github.com/rs/zerolog v1.33.0
 	github.com/xavidop/genkit-aws-bedrock-go v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -206,6 +206,8 @@ github.com/openai/openai-go v1.8.2 h1:UqSkJ1vCOPUpz9Ka5tS0324EJFEuOvMc+lA/EarJWP
 github.com/openai/openai-go v1.8.2/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
 github.com/openai/openai-go/v3 v3.30.0 h1:T8VkhqAm6BuvxwpVG+Aw+H4TcYIsbj9nqytjpWcE/aU=
 github.com/openai/openai-go/v3 v3.30.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=

--- a/internal/adapters/genkit_chat_provider/builtin_tools.go
+++ b/internal/adapters/genkit_chat_provider/builtin_tools.go
@@ -5,24 +5,25 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	md "github.com/JohannesKaufmann/html-to-markdown"
 	"github.com/firebase/genkit/go/ai"
 )
 
 // buildBuiltInTools creates Genkit tool references for the specified built-in tool IDs.
-func buildBuiltInTools(ids []string) []ai.ToolRef {
+func (cp *ChatProvider) buildBuiltInTools(ids []string) []ai.ToolRef {
 	var tools []ai.ToolRef
 	for _, id := range ids {
 		switch id {
 		case "web_fetch":
-			tools = append(tools, buildWebFetchTool())
+			tools = append(tools, cp.buildWebFetchTool())
 		}
 	}
 	return tools
 }
 
-func buildWebFetchTool() ai.Tool {
+func (cp *ChatProvider) buildWebFetchTool() ai.Tool {
 	name := "web_fetch"
 	description := "Fetches static content from a URL and returns it as Markdown. " +
 		"Note: This tool only supports static HTML content. It does not execute JavaScript " +
@@ -49,7 +50,18 @@ func buildWebFetchTool() ai.Tool {
 		if !ok || url == "" {
 			return nil, fmt.Errorf("invalid arguments: 'url' is required and must be a string")
 		}
-		return fetchAsMarkdown(url)
+
+		if cached, ok := cp.cache.Get(toolCtx.Context, url); ok {
+			return cached, nil
+		}
+
+		result, err := fetchAsMarkdown(url)
+		if err != nil {
+			return nil, err
+		}
+
+		_ = cp.cache.Set(toolCtx.Context, url, result, time.Hour)
+		return result, nil
 	}
 
 	return ai.NewTool(name, description, toolFn, ai.WithInputSchema(inputSchema))

--- a/internal/adapters/genkit_chat_provider/provider.go
+++ b/internal/adapters/genkit_chat_provider/provider.go
@@ -20,6 +20,7 @@ import (
 	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
 
 	"github.com/DEEJ4Y/genkitkraft/internal/domain/provider"
+	"github.com/DEEJ4Y/genkitkraft/internal/ports/cache"
 	chatprovider "github.com/DEEJ4Y/genkitkraft/internal/ports/chat_provider"
 )
 
@@ -27,11 +28,13 @@ import (
 var _ chatprovider.ChatProvider = (*ChatProvider)(nil)
 
 // ChatProvider implements chatprovider.ChatProvider using the Genkit Go SDK.
-type ChatProvider struct{}
+type ChatProvider struct {
+	cache cache.Cache
+}
 
 // NewChatProvider creates a new Genkit-based chat provider.
-func NewChatProvider() *ChatProvider {
-	return &ChatProvider{}
+func NewChatProvider(c cache.Cache) *ChatProvider {
+	return &ChatProvider{cache: c}
 }
 
 func (cp *ChatProvider) ChatStream(ctx context.Context, req chatprovider.ChatRequest) (<-chan string, <-chan error) {
@@ -77,7 +80,7 @@ func (cp *ChatProvider) Chat(ctx context.Context, req chatprovider.ChatRequest) 
 	}
 
 	// Build and attach tools
-	tools, mcpCleanup, err := buildTools(ctx, req)
+	tools, mcpCleanup, err := cp.buildTools(ctx, req)
 	if err != nil {
 		return "", fmt.Errorf("building tools: %w", err)
 	}
@@ -131,7 +134,7 @@ func (cp *ChatProvider) doStream(ctx context.Context, req chatprovider.ChatReque
 	}
 
 	// Build and attach tools
-	tools, mcpCleanup, err := buildTools(ctx, req)
+	tools, mcpCleanup, err := cp.buildTools(ctx, req)
 	if err != nil {
 		return fmt.Errorf("building tools: %w", err)
 	}
@@ -298,7 +301,7 @@ func buildOpenAICompatibleConfig(req chatprovider.ChatRequest) any {
 
 // buildTools creates Genkit tool references from the ChatRequest's HTTP tools and MCP server configs.
 // Returns a cleanup function that should be deferred to close MCP connections.
-func buildTools(ctx context.Context, req chatprovider.ChatRequest) ([]ai.ToolRef, func(), error) {
+func (cp *ChatProvider) buildTools(ctx context.Context, req chatprovider.ChatRequest) ([]ai.ToolRef, func(), error) {
 	var tools []ai.ToolRef
 	var mcpClients []*mcp.GenkitMCPClient
 
@@ -309,7 +312,7 @@ func buildTools(ctx context.Context, req chatprovider.ChatRequest) ([]ai.ToolRef
 	}
 
 	// Build built-in tools
-	builtInTools := buildBuiltInTools(req.BuiltInToolIDs)
+	builtInTools := cp.buildBuiltInTools(req.BuiltInToolIDs)
 	tools = append(tools, builtInTools...)
 
 	// Build HTTP tools

--- a/internal/adapters/in_memory_cache/cache.go
+++ b/internal/adapters/in_memory_cache/cache.go
@@ -1,4 +1,4 @@
-package inmemorychache
+package inmemorycache
 
 import (
 	"context"

--- a/internal/adapters/in_memory_cache/cache.go
+++ b/internal/adapters/in_memory_cache/cache.go
@@ -20,6 +20,11 @@ type Cache struct {
 // NewCache creates a new in-memory backing store.
 // cleanupInterval controls how often expired entries are purged from memory.
 // TTLs are always specified per-Set call; there is no global default expiration.
+//
+// NOTE: This store has no maximum-entry cap. A large number of unique keys (e.g.
+// attacker-controlled IPs or URLs) will grow memory without bound. For production
+// deployments or high-traffic environments, replace this adapter with a Redis/Valkey
+// adapter — see GitHub issue #29.
 func NewCache(cleanupInterval time.Duration) *Cache {
 	return &Cache{store: gocache.New(gocache.NoExpiration, cleanupInterval)}
 }

--- a/internal/adapters/in_memory_cache/cache.go
+++ b/internal/adapters/in_memory_cache/cache.go
@@ -18,10 +18,10 @@ type Cache struct {
 }
 
 // NewCache creates a new in-memory backing store.
-// defaultExpiration is used when Set is called with a zero TTL.
 // cleanupInterval controls how often expired entries are purged from memory.
-func NewCache(defaultExpiration, cleanupInterval time.Duration) *Cache {
-	return &Cache{store: gocache.New(defaultExpiration, cleanupInterval)}
+// TTLs are always specified per-Set call; there is no global default expiration.
+func NewCache(cleanupInterval time.Duration) *Cache {
+	return &Cache{store: gocache.New(gocache.NoExpiration, cleanupInterval)}
 }
 
 // Scope returns a Cache where every key is prefixed with "<namespace>:".
@@ -45,5 +45,10 @@ func (r *rawCache) Get(_ context.Context, key string) (string, bool) {
 
 func (r *rawCache) Set(_ context.Context, key string, value string, ttl time.Duration) error {
 	r.store.Set(key, value, ttl)
+	return nil
+}
+
+func (r *rawCache) Delete(_ context.Context, key string) error {
+	r.store.Delete(key)
 	return nil
 }

--- a/internal/adapters/in_memory_cache/cache.go
+++ b/internal/adapters/in_memory_cache/cache.go
@@ -1,0 +1,49 @@
+package inmemorychache
+
+import (
+	"context"
+	"time"
+
+	gocache "github.com/patrickmn/go-cache"
+
+	"github.com/DEEJ4Y/genkitkraft/internal/ports/cache"
+)
+
+var _ cache.Store = (*Cache)(nil)
+
+// Cache is the in-memory backing store. It does not implement cache.Cache directly;
+// use Scope to obtain a namespace-isolated cache.Cache.
+type Cache struct {
+	store *gocache.Cache
+}
+
+// NewCache creates a new in-memory backing store.
+// defaultExpiration is used when Set is called with a zero TTL.
+// cleanupInterval controls how often expired entries are purged from memory.
+func NewCache(defaultExpiration, cleanupInterval time.Duration) *Cache {
+	return &Cache{store: gocache.New(defaultExpiration, cleanupInterval)}
+}
+
+// Scope returns a Cache where every key is prefixed with "<namespace>:".
+func (c *Cache) Scope(namespace string) cache.Cache {
+	return cache.Scope(&rawCache{store: c.store}, namespace)
+}
+
+// rawCache is unexported — it implements cache.Cache and is only used via Scope.
+type rawCache struct {
+	store *gocache.Cache
+}
+
+func (r *rawCache) Get(_ context.Context, key string) (string, bool) {
+	val, found := r.store.Get(key)
+	if !found {
+		return "", false
+	}
+	str, ok := val.(string)
+	return str, ok
+}
+
+func (r *rawCache) Set(_ context.Context, key string, value string, ttl time.Duration) error {
+	r.store.Set(key, value, ttl)
+	return nil
+}

--- a/internal/adapters/memory_session/store.go
+++ b/internal/adapters/memory_session/store.go
@@ -2,12 +2,12 @@ package memorysession
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/DEEJ4Y/genkitkraft/internal/common/errors"
+	"github.com/DEEJ4Y/genkitkraft/internal/ports/cache"
 	"github.com/DEEJ4Y/genkitkraft/internal/ports/session"
 )
 
@@ -16,82 +16,32 @@ const sessionTTL = 24 * time.Hour
 // Compile-time check that MemoryStore implements session.Store.
 var _ session.Store = (*MemoryStore)(nil)
 
-type storedSession struct {
-	Username  string
-	ExpiresAt time.Time
-}
-
-// MemoryStore manages sessions in memory.
+// MemoryStore manages sessions via the cache port. TTL-based expiry replaces the
+// manual cleanup loop that the previous map-based implementation required.
 type MemoryStore struct {
-	mu       sync.RWMutex
-	sessions map[string]storedSession
+	cache cache.Cache
 }
 
-func NewMemoryStore() *MemoryStore {
-	return &MemoryStore{
-		sessions: make(map[string]storedSession),
-	}
+func NewMemoryStore(c cache.Cache) *MemoryStore {
+	return &MemoryStore{cache: c}
 }
 
-func (s *MemoryStore) Create(_ context.Context, username string) (string, error) {
+func (s *MemoryStore) Create(ctx context.Context, username string) (string, error) {
 	token := uuid.New().String()
-	s.mu.Lock()
-	s.sessions[token] = storedSession{
-		Username:  username,
-		ExpiresAt: time.Now().Add(sessionTTL),
+	if err := s.cache.Set(ctx, token, username, sessionTTL); err != nil {
+		return "", err
 	}
-	s.mu.Unlock()
 	return token, nil
 }
 
-func (s *MemoryStore) Validate(_ context.Context, token string) (string, error) {
-	s.mu.RLock()
-	sess, ok := s.sessions[token]
-	s.mu.RUnlock()
-
+func (s *MemoryStore) Validate(ctx context.Context, token string) (string, error) {
+	username, ok := s.cache.Get(ctx, token)
 	if !ok {
 		return "", errors.NewAppError(errors.Unauthorized, "invalid or expired session")
 	}
-	if time.Now().After(sess.ExpiresAt) {
-		s.delete(token)
-		return "", errors.NewAppError(errors.Unauthorized, "invalid or expired session")
-	}
-	return sess.Username, nil
+	return username, nil
 }
 
-func (s *MemoryStore) Delete(_ context.Context, token string) error {
-	s.delete(token)
-	return nil
-}
-
-func (s *MemoryStore) delete(token string) {
-	s.mu.Lock()
-	delete(s.sessions, token)
-	s.mu.Unlock()
-}
-
-func (s *MemoryStore) StartCleanupLoop(done <-chan struct{}) {
-	go func() {
-		ticker := time.NewTicker(1 * time.Hour)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				s.cleanExpired()
-			case <-done:
-				return
-			}
-		}
-	}()
-}
-
-func (s *MemoryStore) cleanExpired() {
-	now := time.Now()
-	s.mu.Lock()
-	for token, sess := range s.sessions {
-		if now.After(sess.ExpiresAt) {
-			delete(s.sessions, token)
-		}
-	}
-	s.mu.Unlock()
+func (s *MemoryStore) Delete(ctx context.Context, token string) error {
+	return s.cache.Delete(ctx, token)
 }

--- a/internal/app/decorators/rate_limit.go
+++ b/internal/app/decorators/rate_limit.go
@@ -35,11 +35,25 @@ func NewRateLimitingLoginDecorator(
 }
 
 func (d *RateLimitingLoginDecorator) Execute(ctx context.Context, params commands.LoginParams) (commands.LoginResult, error) {
-	if !d.checkAndRecord(ctx, params.ClientIP) {
+	ts, ok := d.checkAndRecord(ctx, params.ClientIP)
+	if !ok {
 		return commands.LoginResult{}, errors.NewAppError(errors.TooManyRequests, "too many login attempts, try again later")
 	}
 
+	completed := false
+	defer func() {
+		if !completed {
+			// inner.Execute panicked; remove only the slot we pre-recorded so prior
+			// failures for this IP remain counted.
+			d.mu.Lock()
+			d.removeAttempt(ctx, params.ClientIP, ts)
+			d.mu.Unlock()
+		}
+	}()
+
 	result, err := d.inner.Execute(ctx, params)
+	completed = true
+
 	if err != nil {
 		return result, err
 	}
@@ -52,21 +66,43 @@ func (d *RateLimitingLoginDecorator) Execute(ctx context.Context, params command
 }
 
 // checkAndRecord atomically checks whether the IP is under the rate limit and,
-// if so, pre-records the attempt. Returns false if the limit is already reached.
+// if so, pre-records the attempt. Returns the recorded timestamp and true if
+// allowed, or zero and false if the limit is already reached.
 // The lock is not held during inner.Execute so slow operations (e.g. bcrypt) do
 // not block concurrent requests from other IPs.
-func (d *RateLimitingLoginDecorator) checkAndRecord(ctx context.Context, ip string) bool {
+func (d *RateLimitingLoginDecorator) checkAndRecord(ctx context.Context, ip string) (int64, bool) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	attempts := d.getAttempts(ctx, ip)
 	attempts = prune(attempts)
 	if len(attempts) >= rateLimitMaxFails {
-		return false
+		return 0, false
 	}
-	attempts = append(attempts, time.Now().UnixNano())
+	ts := time.Now().UnixNano()
+	attempts = append(attempts, ts)
 	d.setAttempts(ctx, ip, attempts)
-	return true
+	return ts, true
+}
+
+// removeAttempt removes the single entry with timestamp ts for ip. Called on
+// panic to undo the pre-recorded slot without erasing prior failures.
+func (d *RateLimitingLoginDecorator) removeAttempt(ctx context.Context, ip string, ts int64) {
+	attempts := d.getAttempts(ctx, ip)
+	out := attempts[:0]
+	removed := false
+	for _, t := range attempts {
+		if !removed && t == ts {
+			removed = true
+			continue
+		}
+		out = append(out, t)
+	}
+	if len(out) == 0 {
+		_ = d.cache.Delete(ctx, ip)
+	} else {
+		d.setAttempts(ctx, ip, out)
+	}
 }
 
 func (d *RateLimitingLoginDecorator) getAttempts(ctx context.Context, ip string) []int64 {

--- a/internal/app/decorators/rate_limit.go
+++ b/internal/app/decorators/rate_limit.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog"
+
 	"github.com/DEEJ4Y/genkitkraft/internal/app/commands"
 	"github.com/DEEJ4Y/genkitkraft/internal/app/executors"
 	"github.com/DEEJ4Y/genkitkraft/internal/common/errors"
@@ -22,16 +24,18 @@ var _ executors.ExecutorWithReturn[commands.LoginParams, commands.LoginResult] =
 
 // RateLimitingLoginDecorator wraps a login executor with per-IP rate limiting.
 type RateLimitingLoginDecorator struct {
-	inner executors.ExecutorWithReturn[commands.LoginParams, commands.LoginResult]
-	cache cache.Cache
-	mu    sync.Mutex
+	inner  executors.ExecutorWithReturn[commands.LoginParams, commands.LoginResult]
+	cache  cache.Cache
+	logger zerolog.Logger
+	mu     sync.Mutex
 }
 
 func NewRateLimitingLoginDecorator(
 	inner executors.ExecutorWithReturn[commands.LoginParams, commands.LoginResult],
 	c cache.Cache,
+	logger zerolog.Logger,
 ) *RateLimitingLoginDecorator {
-	return &RateLimitingLoginDecorator{inner: inner, cache: c}
+	return &RateLimitingLoginDecorator{inner: inner, cache: c, logger: logger}
 }
 
 func (d *RateLimitingLoginDecorator) Execute(ctx context.Context, params commands.LoginParams) (commands.LoginResult, error) {
@@ -112,6 +116,7 @@ func (d *RateLimitingLoginDecorator) getAttempts(ctx context.Context, ip string)
 	}
 	var attempts []int64
 	if err := json.Unmarshal([]byte(val), &attempts); err != nil {
+		d.logger.Warn().Err(err).Str("ip", ip).Msg("rate_limit: corrupt attempts data, resetting count")
 		return nil
 	}
 	return attempts

--- a/internal/app/decorators/rate_limit.go
+++ b/internal/app/decorators/rate_limit.go
@@ -3,6 +3,7 @@ package decorators
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"time"
 
 	"github.com/DEEJ4Y/genkitkraft/internal/app/commands"
@@ -20,11 +21,10 @@ const (
 var _ executors.ExecutorWithReturn[commands.LoginParams, commands.LoginResult] = (*RateLimitingLoginDecorator)(nil)
 
 // RateLimitingLoginDecorator wraps a login executor with per-IP rate limiting.
-// Attempt counts are persisted via the cache port. Read-modify-write is not atomic;
-// a distributed cache backend would need atomic ops for strict correctness.
 type RateLimitingLoginDecorator struct {
 	inner executors.ExecutorWithReturn[commands.LoginParams, commands.LoginResult]
 	cache cache.Cache
+	mu    sync.Mutex
 }
 
 func NewRateLimitingLoginDecorator(
@@ -35,31 +35,38 @@ func NewRateLimitingLoginDecorator(
 }
 
 func (d *RateLimitingLoginDecorator) Execute(ctx context.Context, params commands.LoginParams) (commands.LoginResult, error) {
-	if !d.allow(ctx, params.ClientIP) {
+	if !d.checkAndRecord(ctx, params.ClientIP) {
 		return commands.LoginResult{}, errors.NewAppError(errors.TooManyRequests, "too many login attempts, try again later")
 	}
 
 	result, err := d.inner.Execute(ctx, params)
 	if err != nil {
-		d.record(ctx, params.ClientIP)
 		return result, err
 	}
 
+	// Successful login — clear the failure count for this IP.
+	d.mu.Lock()
 	_ = d.cache.Delete(ctx, params.ClientIP)
+	d.mu.Unlock()
 	return result, nil
 }
 
-func (d *RateLimitingLoginDecorator) allow(ctx context.Context, ip string) bool {
-	attempts := d.getAttempts(ctx, ip)
-	attempts = prune(attempts)
-	return len(attempts) < rateLimitMaxFails
-}
+// checkAndRecord atomically checks whether the IP is under the rate limit and,
+// if so, pre-records the attempt. Returns false if the limit is already reached.
+// The lock is not held during inner.Execute so slow operations (e.g. bcrypt) do
+// not block concurrent requests from other IPs.
+func (d *RateLimitingLoginDecorator) checkAndRecord(ctx context.Context, ip string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 
-func (d *RateLimitingLoginDecorator) record(ctx context.Context, ip string) {
 	attempts := d.getAttempts(ctx, ip)
 	attempts = prune(attempts)
+	if len(attempts) >= rateLimitMaxFails {
+		return false
+	}
 	attempts = append(attempts, time.Now().UnixNano())
 	d.setAttempts(ctx, ip, attempts)
+	return true
 }
 
 func (d *RateLimitingLoginDecorator) getAttempts(ctx context.Context, ip string) []int64 {

--- a/internal/app/decorators/rate_limit.go
+++ b/internal/app/decorators/rate_limit.go
@@ -2,12 +2,13 @@ package decorators
 
 import (
 	"context"
-	"sync"
+	"encoding/json"
 	"time"
 
 	"github.com/DEEJ4Y/genkitkraft/internal/app/commands"
 	"github.com/DEEJ4Y/genkitkraft/internal/app/executors"
 	"github.com/DEEJ4Y/genkitkraft/internal/common/errors"
+	"github.com/DEEJ4Y/genkitkraft/internal/ports/cache"
 )
 
 const (
@@ -19,64 +20,77 @@ const (
 var _ executors.ExecutorWithReturn[commands.LoginParams, commands.LoginResult] = (*RateLimitingLoginDecorator)(nil)
 
 // RateLimitingLoginDecorator wraps a login executor with per-IP rate limiting.
+// Attempt counts are persisted via the cache port. Read-modify-write is not atomic;
+// a distributed cache backend would need atomic ops for strict correctness.
 type RateLimitingLoginDecorator struct {
-	inner    executors.ExecutorWithReturn[commands.LoginParams, commands.LoginResult]
-	mu       sync.Mutex
-	attempts map[string][]time.Time
+	inner executors.ExecutorWithReturn[commands.LoginParams, commands.LoginResult]
+	cache cache.Cache
 }
 
 func NewRateLimitingLoginDecorator(
 	inner executors.ExecutorWithReturn[commands.LoginParams, commands.LoginResult],
+	c cache.Cache,
 ) *RateLimitingLoginDecorator {
-	return &RateLimitingLoginDecorator{
-		inner:    inner,
-		attempts: make(map[string][]time.Time),
-	}
+	return &RateLimitingLoginDecorator{inner: inner, cache: c}
 }
 
 func (d *RateLimitingLoginDecorator) Execute(ctx context.Context, params commands.LoginParams) (commands.LoginResult, error) {
-	if !d.allow(params.ClientIP) {
+	if !d.allow(ctx, params.ClientIP) {
 		return commands.LoginResult{}, errors.NewAppError(errors.TooManyRequests, "too many login attempts, try again later")
 	}
 
 	result, err := d.inner.Execute(ctx, params)
 	if err != nil {
-		d.record(params.ClientIP)
+		d.record(ctx, params.ClientIP)
 		return result, err
 	}
 
-	d.reset(params.ClientIP)
+	_ = d.cache.Delete(ctx, params.ClientIP)
 	return result, nil
 }
 
-func (d *RateLimitingLoginDecorator) allow(ip string) bool {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	d.prune(ip)
-	return len(d.attempts[ip]) < rateLimitMaxFails
+func (d *RateLimitingLoginDecorator) allow(ctx context.Context, ip string) bool {
+	attempts := d.getAttempts(ctx, ip)
+	attempts = prune(attempts)
+	return len(attempts) < rateLimitMaxFails
 }
 
-func (d *RateLimitingLoginDecorator) record(ip string) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	d.attempts[ip] = append(d.attempts[ip], time.Now())
+func (d *RateLimitingLoginDecorator) record(ctx context.Context, ip string) {
+	attempts := d.getAttempts(ctx, ip)
+	attempts = prune(attempts)
+	attempts = append(attempts, time.Now().UnixNano())
+	d.setAttempts(ctx, ip, attempts)
 }
 
-func (d *RateLimitingLoginDecorator) reset(ip string) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	delete(d.attempts, ip)
+func (d *RateLimitingLoginDecorator) getAttempts(ctx context.Context, ip string) []int64 {
+	val, ok := d.cache.Get(ctx, ip)
+	if !ok {
+		return nil
+	}
+	var attempts []int64
+	if err := json.Unmarshal([]byte(val), &attempts); err != nil {
+		return nil
+	}
+	return attempts
 }
 
-func (d *RateLimitingLoginDecorator) prune(ip string) {
-	cutoff := time.Now().Add(-rateLimitWindow)
-	attempts := d.attempts[ip]
+func (d *RateLimitingLoginDecorator) setAttempts(ctx context.Context, ip string, attempts []int64) {
+	data, err := json.Marshal(attempts)
+	if err != nil {
+		return
+	}
+	_ = d.cache.Set(ctx, ip, string(data), rateLimitWindow)
+}
+
+// prune removes attempt timestamps that fall outside the rolling window.
+func prune(attempts []int64) []int64 {
+	cutoff := time.Now().Add(-rateLimitWindow).UnixNano()
 	i := 0
 	for _, t := range attempts {
-		if t.After(cutoff) {
+		if t > cutoff {
 			attempts[i] = t
 			i++
 		}
 	}
-	d.attempts[ip] = attempts[:i]
+	return attempts[:i]
 }

--- a/internal/ports/cache/port.go
+++ b/internal/ports/cache/port.go
@@ -11,6 +11,8 @@ type Cache interface {
 	Get(ctx context.Context, key string) (string, bool)
 	// Set stores a value with the given TTL. A zero TTL means no expiration.
 	Set(ctx context.Context, key string, value string, ttl time.Duration) error
+	// Delete removes the entry for key. No-op if the key does not exist.
+	Delete(ctx context.Context, key string) error
 }
 
 // Store is the factory for obtaining namespace-isolated Cache instances.

--- a/internal/ports/cache/port.go
+++ b/internal/ports/cache/port.go
@@ -1,0 +1,20 @@
+package cache
+
+import (
+	"context"
+	"time"
+)
+
+// Cache defines the contract for key-value caching with TTL support.
+type Cache interface {
+	// Get retrieves a value by key. Returns the value and whether it was found and unexpired.
+	Get(ctx context.Context, key string) (string, bool)
+	// Set stores a value with the given TTL. A zero TTL means no expiration.
+	Set(ctx context.Context, key string, value string, ttl time.Duration) error
+}
+
+// Store is the factory for obtaining namespace-isolated Cache instances.
+// Adapters implement Store rather than Cache directly — callers must always call Scope.
+type Store interface {
+	Scope(namespace string) Cache
+}

--- a/internal/ports/cache/scoped.go
+++ b/internal/ports/cache/scoped.go
@@ -1,0 +1,25 @@
+package cache
+
+import (
+	"context"
+	"time"
+)
+
+type scopedCache struct {
+	inner  Cache
+	prefix string
+}
+
+// Scope wraps c so all keys are stored as "<namespace>:<key>".
+// Adapters call this from their own Scope method to reuse this logic.
+func Scope(c Cache, namespace string) Cache {
+	return &scopedCache{inner: c, prefix: namespace + ":"}
+}
+
+func (s *scopedCache) Get(ctx context.Context, key string) (string, bool) {
+	return s.inner.Get(ctx, s.prefix+key)
+}
+
+func (s *scopedCache) Set(ctx context.Context, key string, value string, ttl time.Duration) error {
+	return s.inner.Set(ctx, s.prefix+key, value, ttl)
+}

--- a/internal/ports/cache/scoped.go
+++ b/internal/ports/cache/scoped.go
@@ -23,3 +23,7 @@ func (s *scopedCache) Get(ctx context.Context, key string) (string, bool) {
 func (s *scopedCache) Set(ctx context.Context, key string, value string, ttl time.Duration) error {
 	return s.inner.Set(ctx, s.prefix+key, value, ttl)
 }
+
+func (s *scopedCache) Delete(ctx context.Context, key string) error {
+	return s.inner.Delete(ctx, s.prefix+key)
+}

--- a/internal/ports/session/port.go
+++ b/internal/ports/session/port.go
@@ -7,5 +7,4 @@ type Store interface {
 	Create(ctx context.Context, username string) (token string, err error)
 	Validate(ctx context.Context, token string) (username string, err error)
 	Delete(ctx context.Context, token string) error
-	StartCleanupLoop(done <-chan struct{})
 }

--- a/internal/services/server.go
+++ b/internal/services/server.go
@@ -58,7 +58,6 @@ type Server struct {
 	chatProvider   chatprovider.ChatProvider
 	sessionStore   session.Store
 	db             *sql.DB
-	done           chan struct{}
 }
 
 // NewServer wires all dependencies and returns a ready-to-start Server.
@@ -325,7 +324,6 @@ func NewServer(cfg config.Config) (*Server, error) {
 		chatProvider:   chatProvider,
 		sessionStore:   sessionStore,
 		db:             db,
-		done:           make(chan struct{}),
 	}, nil
 }
 
@@ -357,9 +355,8 @@ func (s *Server) Start() error {
 	return http.ListenAndServe(addr, handler)
 }
 
-// Stop signals background goroutines to stop and releases resources.
+// Stop releases server resources.
 func (s *Server) Stop() {
-	close(s.done)
 	if s.db != nil {
 		s.db.Close()
 	}

--- a/internal/services/server.go
+++ b/internal/services/server.go
@@ -9,12 +9,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog"
 
 	aesgcmencryptor "github.com/DEEJ4Y/genkitkraft/internal/adapters/aesgcm_encryptor"
 	bcrypthasher "github.com/DEEJ4Y/genkitkraft/internal/adapters/bcrypt_hasher"
 	genkitchatprovider "github.com/DEEJ4Y/genkitkraft/internal/adapters/genkit_chat_provider"
+	inmemorychache "github.com/DEEJ4Y/genkitkraft/internal/adapters/in_memory_cache"
 	httpprovidertester "github.com/DEEJ4Y/genkitkraft/internal/adapters/http_provider_tester"
 	mcpdiscoveryadapter "github.com/DEEJ4Y/genkitkraft/internal/adapters/mcp_discovery"
 	memorysession "github.com/DEEJ4Y/genkitkraft/internal/adapters/memory_session"
@@ -278,7 +280,8 @@ func NewServer(cfg config.Config) (*Server, error) {
 
 	// Create playground adapters
 	playgroundRepo := sqliteplayground.NewPlaygroundRepository(db)
-	chatProvider := genkitchatprovider.NewChatProvider()
+	cacheStore := inmemorychache.NewCache(time.Hour, 10*time.Minute)
+	chatProvider := genkitchatprovider.NewChatProvider(cacheStore.Scope("web_fetch"))
 
 	// Create playground commands
 	createSessionCmd := commands.NewCreatePlaygroundSessionCommand(playgroundRepo, agentRepo)

--- a/internal/services/server.go
+++ b/internal/services/server.go
@@ -16,7 +16,7 @@ import (
 	aesgcmencryptor "github.com/DEEJ4Y/genkitkraft/internal/adapters/aesgcm_encryptor"
 	bcrypthasher "github.com/DEEJ4Y/genkitkraft/internal/adapters/bcrypt_hasher"
 	genkitchatprovider "github.com/DEEJ4Y/genkitkraft/internal/adapters/genkit_chat_provider"
-	inmemorychache "github.com/DEEJ4Y/genkitkraft/internal/adapters/in_memory_cache"
+	inmemorycache "github.com/DEEJ4Y/genkitkraft/internal/adapters/in_memory_cache"
 	httpprovidertester "github.com/DEEJ4Y/genkitkraft/internal/adapters/http_provider_tester"
 	mcpdiscoveryadapter "github.com/DEEJ4Y/genkitkraft/internal/adapters/mcp_discovery"
 	memorysession "github.com/DEEJ4Y/genkitkraft/internal/adapters/memory_session"
@@ -73,7 +73,7 @@ func NewServer(cfg config.Config) (*Server, error) {
 	cfg.Encryption.Key = ""
 
 	// Create shared cache store — all scoped caches derive from this single backing store.
-	cacheStore := inmemorychache.NewCache(10 * time.Minute)
+	cacheStore := inmemorycache.NewCache(10 * time.Minute)
 
 	// Create adapters
 	passwordHasher := bcrypthasher.NewBcryptHasher()
@@ -95,7 +95,7 @@ func NewServer(cfg config.Config) (*Server, error) {
 	logoutCmd := commands.NewLogoutCommand(sessionStore)
 
 	// Apply decorators
-	rateLimitedLogin := decorators.NewRateLimitingLoginDecorator(loginCmd, cacheStore.Scope("rate_limit"))
+	rateLimitedLogin := decorators.NewRateLimitingLoginDecorator(loginCmd, cacheStore.Scope("rate_limit"), logger)
 
 	// Create queries
 	getMeQuery := queries.NewGetMeQuery(sessionStore)

--- a/internal/services/server.go
+++ b/internal/services/server.go
@@ -73,9 +73,12 @@ func NewServer(cfg config.Config) (*Server, error) {
 	}
 	cfg.Encryption.Key = ""
 
+	// Create shared cache store — all scoped caches derive from this single backing store.
+	cacheStore := inmemorychache.NewCache(10 * time.Minute)
+
 	// Create adapters
 	passwordHasher := bcrypthasher.NewBcryptHasher()
-	sessionStore := memorysession.NewMemoryStore()
+	sessionStore := memorysession.NewMemoryStore(cacheStore.Scope("session"))
 
 	// Hash credentials using adapter, then discard plaintext
 	users, err := hashCredentials(cfg.Auth.Credentials, passwordHasher)
@@ -93,7 +96,7 @@ func NewServer(cfg config.Config) (*Server, error) {
 	logoutCmd := commands.NewLogoutCommand(sessionStore)
 
 	// Apply decorators
-	rateLimitedLogin := decorators.NewRateLimitingLoginDecorator(loginCmd)
+	rateLimitedLogin := decorators.NewRateLimitingLoginDecorator(loginCmd, cacheStore.Scope("rate_limit"))
 
 	// Create queries
 	getMeQuery := queries.NewGetMeQuery(sessionStore)
@@ -280,7 +283,6 @@ func NewServer(cfg config.Config) (*Server, error) {
 
 	// Create playground adapters
 	playgroundRepo := sqliteplayground.NewPlaygroundRepository(db)
-	cacheStore := inmemorychache.NewCache(time.Hour, 10*time.Minute)
 	chatProvider := genkitchatprovider.NewChatProvider(cacheStore.Scope("web_fetch"))
 
 	// Create playground commands
@@ -329,8 +331,6 @@ func NewServer(cfg config.Config) (*Server, error) {
 
 // Start begins serving HTTP. This blocks until the server stops.
 func (s *Server) Start() error {
-	s.sessionStore.StartCleanupLoop(s.done)
-
 	mux := http.NewServeMux()
 
 	// Register all API routes via generated handler


### PR DESCRIPTION
Main goal was to add caching to webpages that the system fetches using the web_fetch tool.

  ## Summary
  
  - Adds a `cache.Store` port with a `Cache` interface (`Get`/`Set`/`Delete`) and
    namespace-isolated scoping via `Scope(namespace)`
  - Implements the port with an in-memory adapter backed by `go-cache`; TTLs are
    always caller-supplied — no global default expiration
  - Injects scoped caches into three consumers, replacing raw in-memory maps:
    - **`web_fetch` tool** — `Scope("web_fetch")`, 1-hour TTL
    - **Session store** — `Scope("session")`, 24-hour TTL; eliminates the manual
      cleanup goroutine and `StartCleanupLoop` from the `session.Store` port
    - **Rate limiter** — `Scope("rate_limit")`, 1-minute rolling TTL; attempt
      timestamps serialized as JSON
      
  Future swap to Redis/Valkey only requires a new adapter implementing `cache.Store`.