### PR TITLE
feat: v0.4.0 — HTTP timeout, goose NewProvider, credentials restart doc

### DIFF
--- a/internal/adapters/genkit_chat_provider/builtin_tools.go
+++ b/internal/adapters/genkit_chat_provider/builtin_tools.go
@@ -3,7 +3,6 @@ package genkitchatprovider
 import (
 	"fmt"
 	"io"
-	"net/http"
 	"strings"
 	"time"
 
@@ -73,7 +72,7 @@ func fetchAsMarkdown(rawURL string) (string, error) {
 		return "", fmt.Errorf("invalid URL: %w", err)
 	}
 
-	resp, err := http.Get(encodedURL)
+	resp, err := httpClient.Get(encodedURL)
 	if err != nil {
 		return "", fmt.Errorf("fetching URL: %w", err)
 	}

--- a/internal/adapters/genkit_chat_provider/provider.go
+++ b/internal/adapters/genkit_chat_provider/provider.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
@@ -26,6 +27,8 @@ import (
 
 // Compile-time check that ChatProvider implements the port interface.
 var _ chatprovider.ChatProvider = (*ChatProvider)(nil)
+
+var httpClient = &http.Client{Timeout: 30 * time.Second}
 
 // ChatProvider implements chatprovider.ChatProvider using the Genkit Go SDK.
 type ChatProvider struct {
@@ -419,7 +422,7 @@ func executeHttpTool(ctx context.Context, ht chatprovider.HttpToolDefinition, ar
 		httpReq.Header.Set("Content-Type", "application/json")
 	}
 
-	resp, err := http.DefaultClient.Do(httpReq)
+	resp, err := httpClient.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("HTTP tool request failed: %w", err)
 	}

--- a/internal/adapters/sqlite_db/db.go
+++ b/internal/adapters/sqlite_db/db.go
@@ -1,9 +1,11 @@
 package sqlitedb
 
 import (
+	"context"
 	"database/sql"
 	"embed"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -39,13 +41,17 @@ func Open(dbPath string) (*sql.DB, error) {
 }
 
 func runMigrations(db *sql.DB) error {
-	goose.SetBaseFS(migrations)
-
-	if err := goose.SetDialect("sqlite3"); err != nil {
-		return fmt.Errorf("setting goose dialect: %w", err)
+	migFS, err := fs.Sub(migrations, "migrations")
+	if err != nil {
+		return fmt.Errorf("creating migrations sub-FS: %w", err)
 	}
 
-	if err := goose.Up(db, "migrations"); err != nil {
+	provider, err := goose.NewProvider(goose.DialectSQLite3, db, migFS)
+	if err != nil {
+		return fmt.Errorf("setting up goose provider: %w", err)
+	}
+
+	if _, err = provider.Up(context.Background()); err != nil {
 		return fmt.Errorf("running migrations: %w", err)
 	}
 

--- a/website/docs/configuration/authentication.md
+++ b/website/docs/configuration/authentication.md
@@ -18,6 +18,12 @@ AUTH_CREDENTIALS=admin:strongpassword,user2:anotherpassword
 
 Multiple users can be configured by separating credential pairs with commas.
 
+:::note
+
+`AUTH_CREDENTIALS` is read once at startup. If you add, change, or remove credentials, you must **restart the server** for the changes to take effect.
+
+:::
+
 ## Login Flow
 
 1. When auth is enabled, users see a login dialog on first visit


### PR DESCRIPTION
- Add 30s timeout to shared httpClient in genkit_chat_provider (#32)
- Migrate runMigrations to goose.NewProvider, eliminating global state (#31)
- Document AUTH_CREDENTIALS restart requirement in auth docs (#33)