### PR TITLE
fix: observable cache heal (#40) and consistent 503 during cache outage (#41)

### DIFF
--- a/internal/adapters/genkit_chat_provider/builtin_tools.go
+++ b/internal/adapters/genkit_chat_provider/builtin_tools.go
@@ -1,6 +1,7 @@
 package genkitchatprovider
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -50,20 +51,31 @@ func (cp *ChatProvider) buildWebFetchTool() ai.Tool {
 			return nil, fmt.Errorf("invalid arguments: 'url' is required and must be a string")
 		}
 
-		if cached, ok := cp.cache.Get(toolCtx.Context, url); ok {
-			return cached, nil
-		}
-
-		result, err := fetchAsMarkdown(url)
-		if err != nil {
-			return nil, err
-		}
-
-		_ = cp.cache.Set(toolCtx.Context, url, result, time.Hour)
-		return result, nil
+		return cp.webFetch(toolCtx.Context, url)
 	}
 
 	return ai.NewTool(name, description, toolFn, ai.WithInputSchema(inputSchema))
+}
+
+// webFetch is split out of the tool closure so the cache path is reachable from a
+// test without standing up Genkit's action machinery.
+//
+// A cache error is treated as a miss and the page re-fetched. This cache is a
+// latency optimisation, not a source of truth, so an outage should cost a round
+// trip rather than fail the tool call — unlike session lookup, where a miss and an
+// outage mean genuinely different things.
+func (cp *ChatProvider) webFetch(ctx context.Context, url string) (string, error) {
+	if cached, ok, err := cp.cache.Get(ctx, url); err == nil && ok {
+		return cached, nil
+	}
+
+	result, err := fetchAsMarkdown(url)
+	if err != nil {
+		return "", err
+	}
+
+	_ = cp.cache.Set(ctx, url, result, time.Hour)
+	return result, nil
 }
 
 func fetchAsMarkdown(rawURL string) (string, error) {

--- a/internal/adapters/genkit_chat_provider/builtin_tools_test.go
+++ b/internal/adapters/genkit_chat_provider/builtin_tools_test.go
@@ -1,11 +1,74 @@
 package genkitchatprovider
 
 import (
+	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
+
+// stubCache lets each web_fetch test dictate what the cache lookup reports.
+type stubCache struct {
+	getVal string
+	getOK  bool
+	getErr error
+}
+
+func (s *stubCache) Get(context.Context, string) (string, bool, error) {
+	return s.getVal, s.getOK, s.getErr
+}
+func (s *stubCache) Set(context.Context, string, string, time.Duration) error { return nil }
+func (s *stubCache) Delete(context.Context, string) error                     { return nil }
+func (s *stubCache) Increment(context.Context, string, time.Duration) (int64, error) {
+	return 0, nil
+}
+func (s *stubCache) Decrement(context.Context, string) error { return nil }
+
+// Unlike session lookup, a cache error here must not fail the call: web_fetch is a
+// pure cache, so an outage should cost a round trip rather than break the tool.
+func TestWebFetch_CacheErrorRefetches(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Write([]byte("<html><body><h1>Hello</h1></body></html>"))
+	}))
+	defer server.Close()
+
+	cp := &ChatProvider{cache: &stubCache{getErr: io.ErrUnexpectedEOF}}
+
+	got, err := cp.webFetch(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("webFetch with a failing cache: %v", err)
+	}
+	if !strings.Contains(got, "Hello") {
+		t.Errorf("webFetch = %q, want the fetched page", got)
+	}
+	if n := hits.Load(); n != 1 {
+		t.Errorf("origin was hit %d times, want 1 — a cache error must fall through to a fetch", n)
+	}
+}
+
+// The other half: giving Get an error return must not accidentally disable caching.
+func TestWebFetch_CacheHitSkipsFetch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("origin was fetched despite a cache hit")
+	}))
+	defer server.Close()
+
+	cp := &ChatProvider{cache: &stubCache{getVal: "cached markdown", getOK: true}}
+
+	got, err := cp.webFetch(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("webFetch: %v", err)
+	}
+	if got != "cached markdown" {
+		t.Errorf("webFetch = %q, want the cached value", got)
+	}
+}
 
 // The URL is chosen by the model, so the response size is attacker-influenced: the
 // body must be capped rather than read whole into memory.

--- a/internal/adapters/in_memory_cache/cache.go
+++ b/internal/adapters/in_memory_cache/cache.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	gocache "github.com/patrickmn/go-cache"
+	"github.com/rs/zerolog"
 
 	"github.com/DEEJ4Y/genkitkraft/internal/ports/cache"
 )
@@ -22,6 +23,7 @@ type Cache struct {
 	// locks each individual operation but exposes no compare-and-set, so the
 	// not-found-then-create path in Increment needs its own lock to stay atomic.
 	counterMu sync.Mutex
+	logger    zerolog.Logger
 }
 
 // NewCache creates a new in-memory backing store.
@@ -32,8 +34,8 @@ type Cache struct {
 // choice for a single-instance deployment only. Running multiple instances against
 // it gives each its own sessions and its own rate-limit counters — set
 // CACHE_PROVIDER=redis (or valkey) to share state across instances.
-func NewCache(cleanupInterval time.Duration) *Cache {
-	return &Cache{store: gocache.New(gocache.NoExpiration, cleanupInterval)}
+func NewCache(cleanupInterval time.Duration, logger zerolog.Logger) *Cache {
+	return &Cache{store: gocache.New(gocache.NoExpiration, cleanupInterval), logger: logger}
 }
 
 // Scope returns a Cache where every key is prefixed with "<namespace>:".
@@ -46,22 +48,28 @@ type rawCache struct {
 	owner *Cache
 }
 
-func (r *rawCache) Get(_ context.Context, key string) (string, bool) {
+// Get never returns an error: the store is a map in this process, so there is no
+// dependency to be down. The error exists for the Redis adapter's sake, where an
+// outage must stay distinguishable from a miss.
+func (r *rawCache) Get(_ context.Context, key string) (string, bool, error) {
 	val, found := r.owner.store.Get(key)
 	if !found {
-		return "", false
+		return "", false, nil
 	}
 	switch v := val.(type) {
 	case string:
-		return v, true
+		return v, true, nil
 	case int64:
 		// Counters read back as their decimal form. Redis keeps INCR counters and
 		// SET strings in one string keyspace and cannot tell them apart, so matching
 		// that here is what keeps the two adapters interchangeable — and it makes a
 		// Get miss reliable proof that a key is absent.
-		return strconv.FormatInt(v, 10), true
+		return strconv.FormatInt(v, 10), true, nil
 	default:
-		return "", false
+		// Unreachable: only Set (string) and Increment (int64) write here. Reported as
+		// a miss rather than an error because Redis has no way to hold such a value,
+		// and the two adapters must stay interchangeable.
+		return "", false, nil
 	}
 }
 
@@ -94,6 +102,26 @@ func (r *rawCache) Increment(_ context.Context, key string, ttl time.Duration) (
 	// All three start a fresh window: for the first two that is the contract, and
 	// for the last it is self-healing — a stuck non-counter has no way to clear
 	// itself, so erroring would lock the IP out for good.
+	//
+	// Only the non-int64 case is worth reporting: the other two are the ordinary
+	// first increment of a window and would log on every new client, burying the
+	// one case that means something. IncrementInt64's error is a formatted string
+	// with no sentinel to match on, so the cases are separated by reading the key
+	// back — go-cache's Get applies its own expiry check, so anything still present
+	// here is a live value rather than a lapsed counter. The int64 branch is not
+	// dead: Set does not take counterMu, so a concurrent Increment can create the
+	// key between the two calls, and this suppresses that as the non-event it is.
+	if v, found := r.owner.store.Get(key); found {
+		if _, isCounter := v.(int64); !isCounter {
+			// The key is fully qualified (e.g. "rate_limit:1.2.3.4"), so the namespace
+			// identifies the writer. Only rate_limit keys are ever incremented; were
+			// that to change, a namespace holding secrets would need the key elided.
+			r.owner.logger.Warn().
+				Str("key", key).
+				Str("type", fmt.Sprintf("%T", v)).
+				Msg("cache: key held a non-counter value; reset to a fresh counter")
+		}
+	}
 	r.owner.store.Set(key, int64(1), ttl)
 	return 1, nil
 }

--- a/internal/adapters/in_memory_cache/cache_test.go
+++ b/internal/adapters/in_memory_cache/cache_test.go
@@ -1,10 +1,15 @@
 package inmemorycache_test
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/rs/zerolog"
 
 	inmemorycache "github.com/DEEJ4Y/genkitkraft/internal/adapters/in_memory_cache"
 	"github.com/DEEJ4Y/genkitkraft/internal/ports/cache"
@@ -13,14 +18,84 @@ import (
 
 func TestInMemoryCache(t *testing.T) {
 	cachecontract.Run(t, func(t *testing.T) cache.Store {
-		return inmemorycache.NewCache(time.Minute)
+		return inmemorycache.NewCache(time.Minute, zerolog.New(io.Discard))
 	})
+}
+
+// A non-counter under a counter key means either a bug or another writer on the
+// keyspace. Healing it is right, but healing it silently destroys the only
+// evidence it ever happened — the whole point of the reset being observable.
+func TestIncrementLogsWhenHealingANonCounter(t *testing.T) {
+	var buf bytes.Buffer
+	c := inmemorycache.NewCache(time.Minute, zerolog.New(&buf)).Scope("rate_limit")
+	ctx := context.Background()
+
+	if err := c.Set(ctx, "1.2.3.4", "not-a-number", time.Minute); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if _, err := c.Increment(ctx, "1.2.3.4", time.Minute); err != nil {
+		t.Fatalf("Increment: %v", err)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "non-counter") {
+		t.Errorf("heal was not logged; log = %q", logged)
+	}
+	// The fully-qualified key is what tells an operator which namespace was written
+	// to, which is the first thing they need to find the offending writer.
+	if !strings.Contains(logged, "rate_limit:1.2.3.4") {
+		t.Errorf("heal log does not name the fully-qualified key; log = %q", logged)
+	}
+}
+
+// The counterpart to the test above, and the one that keeps the heal log worth
+// reading. Increment creates the key on the first attempt from every client, so
+// logging that path would Warn on every first login from every IP and bury the
+// real signal in noise.
+func TestIncrementDoesNotLogWhenCreatingACounter(t *testing.T) {
+	var buf bytes.Buffer
+	c := inmemorycache.NewCache(time.Minute, zerolog.New(&buf)).Scope("rate_limit")
+
+	if _, err := c.Increment(context.Background(), "1.2.3.4", time.Minute); err != nil {
+		t.Fatalf("Increment: %v", err)
+	}
+
+	if buf.Len() != 0 {
+		t.Errorf("creating a counter logged %q, want nothing", buf.String())
+	}
+}
+
+// An expired counter reaches the same reset path as a corrupt one, and is just as
+// ordinary as a first create: windows are meant to lapse.
+func TestIncrementDoesNotLogWhenCounterExpired(t *testing.T) {
+	var buf bytes.Buffer
+	c := inmemorycache.NewCache(time.Millisecond, zerolog.New(&buf)).Scope("rate_limit")
+	ctx := context.Background()
+
+	if _, err := c.Increment(ctx, "1.2.3.4", 50*time.Millisecond); err != nil {
+		t.Fatalf("Increment: %v", err)
+	}
+	// A fixed sleep is safe here because it is one-directional: oversleeping only
+	// makes expiry more certain. Polling would not work — each poll is an Increment,
+	// which would recreate the very counter being waited on.
+	time.Sleep(150 * time.Millisecond)
+
+	n, err := c.Increment(ctx, "1.2.3.4", 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Increment after expiry: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("Increment after expiry = %d, want 1 (a fresh window)", n)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("an expired counter logged %q, want nothing", buf.String())
+	}
 }
 
 // Increment must not lose counts under concurrent callers — the rate limit
 // depends on every attempt being observed exactly once.
 func TestIncrementIsAtomicUnderConcurrency(t *testing.T) {
-	c := inmemorycache.NewCache(time.Minute).Scope("ns")
+	c := inmemorycache.NewCache(time.Minute, zerolog.New(io.Discard)).Scope("ns")
 	ctx := context.Background()
 
 	const goroutines = 50
@@ -62,7 +137,7 @@ func TestIncrementIsAtomicUnderConcurrency(t *testing.T) {
 // Verified by mutation: against the old check-then-increment this observes ~270
 // errors per second; against the current implementation it observes zero.
 func TestIncrementNeverErrorsAtTheWindowBoundary(t *testing.T) {
-	c := inmemorycache.NewCache(time.Millisecond).Scope("ns")
+	c := inmemorycache.NewCache(time.Millisecond, zerolog.New(io.Discard)).Scope("ns")
 	ctx := context.Background()
 
 	const (

--- a/internal/adapters/memory_session/store.go
+++ b/internal/adapters/memory_session/store.go
@@ -35,7 +35,13 @@ func (s *MemoryStore) Create(ctx context.Context, username string) (string, erro
 }
 
 func (s *MemoryStore) Validate(ctx context.Context, token string) (string, error) {
-	username, ok := s.cache.Get(ctx, token)
+	username, ok, err := s.cache.Get(ctx, token)
+	if err != nil {
+		// An outage is not an invalid session. Unauthorized would send the user to a
+		// login that cannot succeed while the store backing sessions is down — and it
+		// would disguise the outage as an ordinary expiry.
+		return "", errors.NewAppError(errors.Unavailable, "session store is temporarily unavailable, try again later")
+	}
 	if !ok {
 		return "", errors.NewAppError(errors.Unauthorized, "invalid or expired session")
 	}

--- a/internal/adapters/memory_session/store_test.go
+++ b/internal/adapters/memory_session/store_test.go
@@ -2,8 +2,11 @@ package memorysession_test
 
 import (
 	"context"
+	"io"
 	"testing"
 	"time"
+
+	"github.com/rs/zerolog"
 
 	inmemorycache "github.com/DEEJ4Y/genkitkraft/internal/adapters/in_memory_cache"
 	memorysession "github.com/DEEJ4Y/genkitkraft/internal/adapters/memory_session"
@@ -12,7 +15,7 @@ import (
 
 func newStore(t *testing.T) *memorysession.MemoryStore {
 	t.Helper()
-	return memorysession.NewMemoryStore(inmemorycache.NewCache(time.Minute).Scope("session"))
+	return memorysession.NewMemoryStore(inmemorycache.NewCache(time.Minute, zerolog.New(io.Discard)).Scope("session"))
 }
 
 func TestCreateThenValidate(t *testing.T) {
@@ -111,7 +114,43 @@ func TestSessionsAreIndependent(t *testing.T) {
 	}
 }
 
+// failingCache stands in for a cache backend that is down.
+type failingCache struct{ err error }
+
+func (f *failingCache) Get(context.Context, string) (string, bool, error) { return "", false, f.err }
+func (f *failingCache) Set(context.Context, string, string, time.Duration) error {
+	return f.err
+}
+func (f *failingCache) Delete(context.Context, string) error { return f.err }
+func (f *failingCache) Increment(context.Context, string, time.Duration) (int64, error) {
+	return 0, f.err
+}
+func (f *failingCache) Decrement(context.Context, string) error { return f.err }
+
+// A cache outage must not read as an expired session. Unauthorized would tell the
+// user to log in again — which cannot work while the store backing sessions is
+// down, and login itself answers 503 — so the API would describe two different
+// failures at once. The tests above pin the other side of this: a genuine miss is
+// still a logout, so the error path must not swallow them.
+func TestValidateReportsCacheOutageAsUnavailable(t *testing.T) {
+	s := memorysession.NewMemoryStore(&failingCache{err: io.ErrUnexpectedEOF})
+
+	_, err := s.Validate(context.Background(), "some-token")
+
+	assertUnavailable(t, err)
+}
+
 func assertUnauthorized(t *testing.T, err error) {
+	t.Helper()
+	assertCode(t, err, errors.Unauthorized)
+}
+
+func assertUnavailable(t *testing.T, err error) {
+	t.Helper()
+	assertCode(t, err, errors.Unavailable)
+}
+
+func assertCode(t *testing.T, err error, want errors.ErrorCode) {
 	t.Helper()
 	if err == nil {
 		t.Fatal("want an error, got nil")
@@ -120,7 +159,7 @@ func assertUnauthorized(t *testing.T, err error) {
 	if !ok {
 		t.Fatalf("want *errors.AppError, got %T: %v", err, err)
 	}
-	if appErr.Code() != errors.Unauthorized {
-		t.Errorf("error code = %v, want %v", appErr.Code(), errors.Unauthorized)
+	if appErr.Code() != want {
+		t.Errorf("error code = %v, want %v", appErr.Code(), want)
 	}
 }

--- a/internal/adapters/redis_cache/cache.go
+++ b/internal/adapters/redis_cache/cache.go
@@ -6,11 +6,13 @@ package rediscache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
 
 	"github.com/DEEJ4Y/genkitkraft/internal/ports/cache"
 )
@@ -35,6 +37,11 @@ const pingTimeout = 5 * time.Second
 // come from a bug or an outside writer, but it has to be recoverable: a leftover
 // string may carry no TTL, so nothing would ever clear it and erroring would lock
 // the IP out for good. Reset it and start a fresh window instead.
+//
+// The script returns {n, healed} rather than a bare n so the caller can report
+// that reset. A heal and an ordinary first create both yield n == 1, so the count
+// alone cannot tell them apart, and healing silently would destroy the only
+// evidence that something else is writing to this keyspace.
 var incrementScript = redis.NewScript(`
 local ttl = tonumber(ARGV[1])
 local n = redis.pcall('INCR', KEYS[1])
@@ -44,12 +51,12 @@ if type(n) == 'table' and n.err then
   else
     redis.call('SET', KEYS[1], 1)
   end
-  return 1
+  return {1, 1}
 end
 if n == 1 and ttl > 0 then
   redis.call('PEXPIRE', KEYS[1], ttl)
 end
-return n
+return {n, 0}
 `)
 
 // decrementScript decrements only an existing counter. A plain DECR creates a
@@ -67,11 +74,12 @@ return redis.call('DECR', KEYS[1])
 // directly; use Scope to obtain a namespace-isolated cache.Cache.
 type Cache struct {
 	client *redis.Client
+	logger zerolog.Logger
 }
 
 // NewCache connects to the Redis/Valkey server at rawURL and verifies the
 // connection before returning.
-func NewCache(rawURL string) (*Cache, error) {
+func NewCache(rawURL string, logger zerolog.Logger) (*Cache, error) {
 	opts, err := redis.ParseURL(normalizeURL(rawURL))
 	if err != nil {
 		return nil, fmt.Errorf("parsing cache URL: %w", err)
@@ -86,7 +94,7 @@ func NewCache(rawURL string) (*Cache, error) {
 		return nil, fmt.Errorf("pinging cache: %w", err)
 	}
 
-	return &Cache{client: client}, nil
+	return &Cache{client: client, logger: logger}, nil
 }
 
 // normalizeURL maps the Valkey URL schemes onto their Redis equivalents.
@@ -110,23 +118,28 @@ func (c *Cache) Close() error {
 
 // Scope returns a Cache where every key is prefixed with "<namespace>:".
 func (c *Cache) Scope(namespace string) cache.Cache {
-	return cache.Scope(&rawCache{client: c.client}, namespace)
+	return cache.Scope(&rawCache{client: c.client, logger: c.logger}, namespace)
 }
 
 // rawCache is unexported — it implements cache.Cache and is only used via Scope.
 type rawCache struct {
 	client *redis.Client
+	logger zerolog.Logger
 }
 
-// Get reports a miss for any error, including a connection failure. The port
-// signature has no error return, so an outage is indistinguishable from an
-// expired key here: sessions fail closed and the user is asked to log in again.
-func (r *rawCache) Get(ctx context.Context, key string) (string, bool) {
+// Get separates a genuine miss (redis.Nil) from a failure to reach the server.
+// The split is the whole point: an outage reported as a miss makes session
+// validation answer "log in again", which cannot succeed while the store backing
+// sessions is down — and hides the outage from whoever is on call.
+func (r *rawCache) Get(ctx context.Context, key string) (string, bool, error) {
 	val, err := r.client.Get(ctx, key).Result()
-	if err != nil {
-		return "", false
+	if errors.Is(err, redis.Nil) {
+		return "", false, nil
 	}
-	return val, true
+	if err != nil {
+		return "", false, fmt.Errorf("cache: getting %q: %w", key, err)
+	}
+	return val, true, nil
 }
 
 func (r *rawCache) Set(ctx context.Context, key string, value string, ttl time.Duration) error {
@@ -139,11 +152,22 @@ func (r *rawCache) Delete(ctx context.Context, key string) error {
 }
 
 func (r *rawCache) Increment(ctx context.Context, key string, ttl time.Duration) (int64, error) {
-	n, err := incrementScript.Run(ctx, r.client, []string{key}, ttl.Milliseconds()).Int64()
+	res, err := incrementScript.Run(ctx, r.client, []string{key}, ttl.Milliseconds()).Int64Slice()
 	if err != nil {
 		return 0, fmt.Errorf("cache: incrementing %q: %w", key, err)
 	}
-	return n, nil
+	if len(res) != 2 {
+		return 0, fmt.Errorf("cache: incrementing %q: script returned %d values, want 2", key, len(res))
+	}
+	if res[1] == 1 {
+		// The key is fully qualified (e.g. "rate_limit:1.2.3.4"), so the namespace
+		// identifies the writer. Only rate_limit keys are ever incremented; were that
+		// to change, a namespace holding secrets would need the key elided.
+		r.logger.Warn().
+			Str("key", key).
+			Msg("cache: key held a non-counter value; reset to a fresh counter")
+	}
+	return res[0], nil
 }
 
 func (r *rawCache) Decrement(ctx context.Context, key string) error {

--- a/internal/adapters/redis_cache/cache_test.go
+++ b/internal/adapters/redis_cache/cache_test.go
@@ -3,12 +3,15 @@
 package rediscache_test
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
 
 	rediscache "github.com/DEEJ4Y/genkitkraft/internal/adapters/redis_cache"
 	"github.com/DEEJ4Y/genkitkraft/internal/ports/cache"
@@ -31,7 +34,7 @@ func testCache(t *testing.T, url string) {
 		// empty store the contract expects.
 		flushDB(t, url)
 
-		store, err := rediscache.NewCache(url)
+		store, err := rediscache.NewCache(url, zerolog.New(io.Discard))
 		if err != nil {
 			t.Fatalf("NewCache: %v", err)
 		}
@@ -40,13 +43,70 @@ func testCache(t *testing.T, url string) {
 	})
 }
 
+// The Redis heal happens inside the Lua script, and a heal and an ordinary first
+// create both return 1 — the count alone cannot tell them apart. These two tests
+// are what prove the script's second return value actually discriminates; without
+// the negative case, returning a constant 1 for healed would pass.
+func TestIncrementLogsWhenHealingANonCounter(t *testing.T) {
+	url := containers.StartRedisURL(t)
+	flushDB(t, url)
+
+	var buf bytes.Buffer
+	store, err := rediscache.NewCache(url, zerolog.New(&buf))
+	if err != nil {
+		t.Fatalf("NewCache: %v", err)
+	}
+	defer store.Close()
+
+	c := store.Scope("rate_limit")
+	ctx := context.Background()
+	if err := c.Set(ctx, "1.2.3.4", "not-a-number", time.Minute); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	n, err := c.Increment(ctx, "1.2.3.4", time.Minute)
+	if err != nil {
+		t.Fatalf("Increment: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("Increment over a non-counter = %d, want 1 (a fresh counter)", n)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "non-counter") {
+		t.Errorf("heal was not logged; log = %q", logged)
+	}
+	if !strings.Contains(logged, "rate_limit:1.2.3.4") {
+		t.Errorf("heal log does not name the fully-qualified key; log = %q", logged)
+	}
+}
+
+func TestIncrementDoesNotLogWhenCreatingACounter(t *testing.T) {
+	url := containers.StartRedisURL(t)
+	flushDB(t, url)
+
+	var buf bytes.Buffer
+	store, err := rediscache.NewCache(url, zerolog.New(&buf))
+	if err != nil {
+		t.Fatalf("NewCache: %v", err)
+	}
+	defer store.Close()
+
+	if _, err := store.Scope("rate_limit").Increment(context.Background(), "1.2.3.4", time.Minute); err != nil {
+		t.Fatalf("Increment: %v", err)
+	}
+
+	if buf.Len() != 0 {
+		t.Errorf("creating a counter logged %q, want nothing", buf.String())
+	}
+}
+
 // Valkey deployments are commonly addressed with a valkey:// URL, which go-redis
 // does not recognise — the adapter must accept it.
 func TestValkeySchemeIsAccepted(t *testing.T) {
 	url := containers.StartValkeyURL(t)
 	valkeyURL := "valkey://" + strings.TrimPrefix(url, "redis://")
 
-	store, err := rediscache.NewCache(valkeyURL)
+	store, err := rediscache.NewCache(valkeyURL, zerolog.New(io.Discard))
 	if err != nil {
 		t.Fatalf("NewCache(%q): %v", valkeyURL, err)
 	}
@@ -57,7 +117,11 @@ func TestValkeySchemeIsAccepted(t *testing.T) {
 	if err := c.Set(ctx, "key", "value", time.Minute); err != nil {
 		t.Fatalf("Set: %v", err)
 	}
-	if got, ok := c.Get(ctx, "key"); !ok || got != "value" {
+	got, ok, err := c.Get(ctx, "key")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !ok || got != "value" {
 		t.Errorf("Get = (%q, %v), want (%q, true)", got, ok, "value")
 	}
 }
@@ -66,13 +130,13 @@ func TestValkeySchemeIsAccepted(t *testing.T) {
 // rather than serving 401s once traffic arrives.
 func TestNewCacheFailsOnUnreachableServer(t *testing.T) {
 	// Port 1 is reserved and never listening.
-	if _, err := rediscache.NewCache("redis://127.0.0.1:1"); err == nil {
+	if _, err := rediscache.NewCache("redis://127.0.0.1:1", zerolog.New(io.Discard)); err == nil {
 		t.Error("NewCache against an unreachable server: want error, got nil")
 	}
 }
 
 func TestNewCacheFailsOnMalformedURL(t *testing.T) {
-	if _, err := rediscache.NewCache("not-a-url"); err == nil {
+	if _, err := rediscache.NewCache("not-a-url", zerolog.New(io.Discard)); err == nil {
 		t.Error("NewCache with a malformed URL: want error, got nil")
 	}
 }
@@ -83,13 +147,13 @@ func TestSeparateInstancesShareState(t *testing.T) {
 	url := containers.StartRedisURL(t)
 	flushDB(t, url)
 
-	instanceA, err := rediscache.NewCache(url)
+	instanceA, err := rediscache.NewCache(url, zerolog.New(io.Discard))
 	if err != nil {
 		t.Fatalf("NewCache: %v", err)
 	}
 	defer instanceA.Close()
 
-	instanceB, err := rediscache.NewCache(url)
+	instanceB, err := rediscache.NewCache(url, zerolog.New(io.Discard))
 	if err != nil {
 		t.Fatalf("NewCache: %v", err)
 	}
@@ -100,7 +164,10 @@ func TestSeparateInstancesShareState(t *testing.T) {
 		t.Fatalf("Set on instance A: %v", err)
 	}
 
-	got, ok := instanceB.Scope("session").Get(ctx, "token")
+	got, ok, err := instanceB.Scope("session").Get(ctx, "token")
+	if err != nil {
+		t.Fatalf("Get on instance B: %v", err)
+	}
 	if !ok {
 		t.Fatal("token written on instance A is not visible on instance B")
 	}

--- a/internal/app/decorators/rate_limit_test.go
+++ b/internal/app/decorators/rate_limit_test.go
@@ -43,7 +43,7 @@ func newDecorator(inner *stubLogin, c cache.Cache) *decorators.RateLimitingLogin
 
 func newSharedCache(t *testing.T) cache.Store {
 	t.Helper()
-	return inmemorycache.NewCache(time.Minute)
+	return inmemorycache.NewCache(time.Minute, zerolog.New(io.Discard))
 }
 
 func badCredentials() error {
@@ -217,7 +217,7 @@ func TestPanicReleasesItsAttempt(t *testing.T) {
 // failingCache stands in for a cache backend that is down.
 type failingCache struct{ err error }
 
-func (f *failingCache) Get(context.Context, string) (string, bool) { return "", false }
+func (f *failingCache) Get(context.Context, string) (string, bool, error) { return "", false, f.err }
 func (f *failingCache) Set(context.Context, string, string, time.Duration) error {
 	return f.err
 }

--- a/internal/handlers/http_handler/interceptors/auth_middleware.go
+++ b/internal/handlers/http_handler/interceptors/auth_middleware.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DEEJ4Y/genkitkraft/internal/api/gen"
 	"github.com/DEEJ4Y/genkitkraft/internal/app"
 	"github.com/DEEJ4Y/genkitkraft/internal/app/queries"
+	"github.com/DEEJ4Y/genkitkraft/internal/common/errors"
 )
 
 type contextKey string
@@ -63,7 +64,7 @@ func AuthMiddleware(authApp *app.AuthApp) func(http.Handler) http.Handler {
 
 			result, err := authApp.Queries.GetMe.Execute(r.Context(), queries.GetMeParams{Token: cookie.Value})
 			if err != nil {
-				writeUnauthorized(w)
+				writeAuthError(w, err)
 				return
 			}
 
@@ -79,6 +80,23 @@ func isPublicPath(path string) bool {
 		return true
 	}
 	return false
+}
+
+// writeAuthError surfaces a dependency outage and fails closed on everything else.
+//
+// A cache outage is not a bad credential: answering 401 sends the user to a login
+// that returns 503 anyway, so the two halves of the API would describe different
+// failures. Every other code deliberately collapses to 401 rather than going
+// through writeAppError — this is the auth gate, and a session lookup has no
+// business returning a 404 or a 409 to an unauthenticated caller.
+func writeAuthError(w http.ResponseWriter, err error) {
+	if appErr, ok := errors.IsAppError(err); ok && appErr.Code() == errors.Unavailable {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(errors.HTTPStatusCode(appErr.Code()))
+		json.NewEncoder(w).Encode(gen.ModelsErrorResponse{Error: appErr.Error()})
+		return
+	}
+	writeUnauthorized(w)
 }
 
 func writeUnauthorized(w http.ResponseWriter) {

--- a/internal/handlers/http_handler/interceptors/auth_middleware_test.go
+++ b/internal/handlers/http_handler/interceptors/auth_middleware_test.go
@@ -1,0 +1,115 @@
+package interceptors_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DEEJ4Y/genkitkraft/internal/app"
+	"github.com/DEEJ4Y/genkitkraft/internal/app/queries"
+	"github.com/DEEJ4Y/genkitkraft/internal/common/errors"
+	"github.com/DEEJ4Y/genkitkraft/internal/handlers/http_handler/interceptors"
+)
+
+type stubGetMe struct{ err error }
+
+func (s stubGetMe) Execute(context.Context, queries.GetMeParams) (queries.GetMeResult, error) {
+	if s.err != nil {
+		return queries.GetMeResult{}, s.err
+	}
+	return queries.GetMeResult{Username: "alice"}, nil
+}
+
+type stubAuthStatus struct{}
+
+func (stubAuthStatus) Execute(context.Context, queries.GetAuthStatusParams) (queries.GetAuthStatusResult, error) {
+	return queries.GetAuthStatusResult{Required: true}, nil
+}
+
+// serve runs a request with a session cookie through the middleware and reports
+// the status the middleware produced. The wrapped handler writes 200, so any other
+// status is the middleware's own answer.
+func serve(t *testing.T, getMeErr error) int {
+	t.Helper()
+
+	authApp := &app.AuthApp{
+		Queries: app.AuthQueries{
+			GetMe:         stubGetMe{err: getMeErr},
+			GetAuthStatus: stubAuthStatus{},
+		},
+	}
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/me", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "some-token"})
+	rec := httptest.NewRecorder()
+
+	interceptors.AuthMiddleware(authApp)(next).ServeHTTP(rec, req)
+	return rec.Code
+}
+
+// The point of the change: during a cache outage every authenticated route used to
+// answer 401 while login answered 503, so the user was bounced between a "you are
+// logged out" that sent them to a login page that then said "we are broken". This
+// middleware — not the session store — is what emitted those 401s, so without it
+// honouring the code the session store's Unavailable never reaches the client.
+func TestAuthMiddlewareReportsCacheOutageAs503(t *testing.T) {
+	got := serve(t, errors.NewAppError(errors.Unavailable, "session store is temporarily unavailable, try again later"))
+
+	if got != http.StatusServiceUnavailable {
+		t.Errorf("status during a cache outage = %d, want %d", got, http.StatusServiceUnavailable)
+	}
+}
+
+// A genuine expired or unknown session is still a logout, and must stay a 401.
+func TestAuthMiddlewareReportsInvalidSessionAs401(t *testing.T) {
+	got := serve(t, errors.NewAppError(errors.Unauthorized, "invalid or expired session"))
+
+	if got != http.StatusUnauthorized {
+		t.Errorf("status for an invalid session = %d, want %d", got, http.StatusUnauthorized)
+	}
+}
+
+// Everything that is not a recognised outage must fail closed at the auth gate.
+// This is the guard against mapping the code straight through: a session lookup
+// returning some other AppError must not leak its status to an unauthenticated
+// caller, and a bare error must not surface as a 500 from the gate.
+func TestAuthMiddlewareFailsClosedOnUnexpectedError(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+	}{
+		{"bare error", io.ErrUnexpectedEOF},
+		{"unrelated app error", errors.NewAppError(errors.NotFound, "nope")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := serve(t, tt.err); got != http.StatusUnauthorized {
+				t.Errorf("status = %d, want %d", got, http.StatusUnauthorized)
+			}
+		})
+	}
+}
+
+// A request with no cookie never reaches the session store, so it stays a 401.
+func TestAuthMiddlewareRejectsMissingCookieAs401(t *testing.T) {
+	authApp := &app.AuthApp{
+		Queries: app.AuthQueries{
+			GetMe:         stubGetMe{},
+			GetAuthStatus: stubAuthStatus{},
+		},
+	}
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	interceptors.AuthMiddleware(authApp)(next).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/auth/me", nil))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status without a session cookie = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}

--- a/internal/ports/cache/port.go
+++ b/internal/ports/cache/port.go
@@ -7,8 +7,15 @@ import (
 
 // Cache defines the contract for key-value caching with TTL support.
 type Cache interface {
-	// Get retrieves a value by key. Returns the value and whether it was found and unexpired.
-	Get(ctx context.Context, key string) (string, bool)
+	// Get retrieves a value by key. It reports whether the key was found and
+	// unexpired, and returns a non-nil error only when the backing store could not
+	// answer at all — a connection failure, say.
+	//
+	// A miss and an outage are different facts and must not be conflated: found is
+	// false for both, but only an error means "we do not know". A caller that fails
+	// closed on a miss — session validation above all — would otherwise report a
+	// dependency outage as an expired session. Check the error before the flag.
+	Get(ctx context.Context, key string) (string, bool, error)
 	// Set stores a value with the given TTL. A zero TTL means no expiration.
 	Set(ctx context.Context, key string, value string, ttl time.Duration) error
 	// Delete removes the entry for key. No-op if the key does not exist.

--- a/internal/ports/cache/scoped.go
+++ b/internal/ports/cache/scoped.go
@@ -16,7 +16,7 @@ func Scope(c Cache, namespace string) Cache {
 	return &scopedCache{inner: c, prefix: namespace + ":"}
 }
 
-func (s *scopedCache) Get(ctx context.Context, key string) (string, bool) {
+func (s *scopedCache) Get(ctx context.Context, key string) (string, bool, error) {
 	return s.inner.Get(ctx, s.prefix+key)
 }
 

--- a/internal/services/server.go
+++ b/internal/services/server.go
@@ -93,6 +93,8 @@ type Server struct {
 
 // NewServer wires all dependencies and returns a ready-to-start Server.
 func NewServer(cfg config.Config) (*Server, error) {
+	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+
 	if cfg.Encryption.Key == "" {
 		return nil, fmt.Errorf("ENCRYPTION_KEY environment variable is required")
 	}
@@ -112,13 +114,13 @@ func NewServer(cfg config.Config) (*Server, error) {
 	switch cfg.Cache.Provider {
 	case "redis", "valkey":
 		// Valkey is protocol-compatible with Redis, so both share one adapter.
-		redisStore, err := rediscache.NewCache(cfg.Cache.URL)
+		redisStore, err := rediscache.NewCache(cfg.Cache.URL, logger)
 		if err != nil {
 			return nil, fmt.Errorf("opening cache (%s): %w", cfg.Cache.Provider, err)
 		}
 		cacheStore = redisStore
 	case "memory":
-		cacheStore = inmemorycache.NewCache(10 * time.Minute)
+		cacheStore = inmemorycache.NewCache(10*time.Minute, logger)
 	default:
 		// Deliberately not falling back to memory: a typo would silently give each
 		// instance its own sessions and rate-limit counters, which is the exact
@@ -139,8 +141,6 @@ func NewServer(cfg config.Config) (*Server, error) {
 	cfg.Auth.Credentials = nil
 
 	authRequired := len(users) > 0
-
-	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
 
 	// Create commands
 	loginCmd := commands.NewLoginCommand(users, sessionStore, passwordHasher)
@@ -371,7 +371,7 @@ func NewServer(cfg config.Config) (*Server, error) {
 	// means the isolation holds under every configuration; the cost is one extra
 	// store and a cold fetch per instance, and a stale cached page is harmless in a
 	// way a dropped session is not.
-	webFetchStore := inmemorycache.NewCache(10 * time.Minute)
+	webFetchStore := inmemorycache.NewCache(10*time.Minute, logger)
 	chatProvider := genkitchatprovider.NewChatProvider(webFetchStore.Scope("web_fetch"))
 
 	// Create playground commands

--- a/resources/test/cachecontract/contract.go
+++ b/resources/test/cachecontract/contract.go
@@ -25,7 +25,10 @@ func Run(t *testing.T, newStore func(t *testing.T) cache.Store) {
 		if err := c.Set(ctx, "key", "value", time.Minute); err != nil {
 			t.Fatalf("Set: %v", err)
 		}
-		got, ok := c.Get(ctx, "key")
+		got, ok, err := c.Get(ctx, "key")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
 		if !ok {
 			t.Fatal("Get: want found, got miss")
 		}
@@ -34,9 +37,17 @@ func Run(t *testing.T, newStore func(t *testing.T) cache.Store) {
 		}
 	})
 
+	// A miss and an outage are different facts. An adapter reporting an absent key as
+	// an error would make every caller read "not cached" as a dependency failure;
+	// one reporting an outage as a miss is the bug this error return exists to
+	// prevent, and only a networked adapter can exhibit it.
 	t.Run("GetMissing", func(t *testing.T) {
 		c := newStore(t).Scope("ns")
-		if _, ok := c.Get(context.Background(), "absent"); ok {
+		_, ok, err := c.Get(context.Background(), "absent")
+		if err != nil {
+			t.Fatalf("Get on an absent key: want a nil error, got %v", err)
+		}
+		if ok {
 			t.Error("Get on absent key: want miss, got found")
 		}
 	})
@@ -51,7 +62,9 @@ func Run(t *testing.T, newStore func(t *testing.T) cache.Store) {
 		if err := c.Delete(ctx, "key"); err != nil {
 			t.Fatalf("Delete: %v", err)
 		}
-		if _, ok := c.Get(ctx, "key"); ok {
+		if _, ok, err := c.Get(ctx, "key"); err != nil {
+			t.Fatalf("Get after Delete: %v", err)
+		} else if ok {
 			t.Error("Get after Delete: want miss, got found")
 		}
 	})
@@ -70,12 +83,14 @@ func Run(t *testing.T, newStore func(t *testing.T) cache.Store) {
 		if err := c.Set(ctx, "key", "value", 100*time.Millisecond); err != nil {
 			t.Fatalf("Set: %v", err)
 		}
-		if _, ok := c.Get(ctx, "key"); !ok {
+		if _, ok, err := c.Get(ctx, "key"); err != nil {
+			t.Fatalf("Get before TTL: %v", err)
+		} else if !ok {
 			t.Fatal("Get before TTL: want found, got miss")
 		}
 		if !eventually(t, 2*time.Second, func() bool {
-			_, ok := c.Get(ctx, "key")
-			return !ok
+			_, ok, err := c.Get(ctx, "key")
+			return err == nil && !ok
 		}) {
 			t.Error("key still present well after its TTL elapsed")
 		}
@@ -89,14 +104,19 @@ func Run(t *testing.T, newStore func(t *testing.T) cache.Store) {
 		if err := a.Set(ctx, "key", "from-alpha", time.Minute); err != nil {
 			t.Fatalf("Set: %v", err)
 		}
-		if _, ok := b.Get(ctx, "key"); ok {
+		if _, ok, err := b.Get(ctx, "key"); err != nil {
+			t.Fatalf("Get: %v", err)
+		} else if ok {
 			t.Error("key written in one namespace is visible in another")
 		}
 
 		if err := b.Set(ctx, "key", "from-beta", time.Minute); err != nil {
 			t.Fatalf("Set: %v", err)
 		}
-		got, ok := a.Get(ctx, "key")
+		got, ok, err := a.Get(ctx, "key")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
 		if !ok || got != "from-alpha" {
 			t.Errorf("alpha key = (%q, %v) after beta wrote the same key, want (%q, true)", got, ok, "from-alpha")
 		}
@@ -200,7 +220,9 @@ func Run(t *testing.T, newStore func(t *testing.T) cache.Store) {
 		if err := c.Decrement(ctx, "absent"); err != nil {
 			t.Errorf("Decrement on absent key: %v", err)
 		}
-		if _, ok := c.Get(ctx, "absent"); ok {
+		if _, ok, err := c.Get(ctx, "absent"); err != nil {
+			t.Fatalf("Get: %v", err)
+		} else if ok {
 			t.Error("Decrement on an absent key created it")
 		}
 		n, err := c.Increment(ctx, "absent", time.Minute)
@@ -246,7 +268,10 @@ func Run(t *testing.T, newStore func(t *testing.T) cache.Store) {
 				t.Fatalf("Increment: %v", err)
 			}
 		}
-		got, ok := c.Get(ctx, "counter")
+		got, ok, err := c.Get(ctx, "counter")
+		if err != nil {
+			t.Fatalf("Get on a counter: %v", err)
+		}
 		if !ok {
 			t.Fatal("Get on a counter: want found, got miss")
 		}

--- a/spec/routes/auth.tsp
+++ b/spec/routes/auth.tsp
@@ -41,6 +41,9 @@ namespace Auth {
   op logout(): LogoutResponse | {
     @statusCode statusCode: 401;
     @body body: ErrorResponse;
+  } | {
+    @statusCode statusCode: 503;
+    @body body: ErrorResponse;
   };
 
   /** Get the currently authenticated user. */
@@ -50,6 +53,9 @@ namespace Auth {
   @operationId("getMe")
   op me(): MeResponse | {
     @statusCode statusCode: 401;
+    @body body: ErrorResponse;
+  } | {
+    @statusCode statusCode: 503;
     @body body: ErrorResponse;
   };
 }

--- a/spec/tsp-output/schema/openapi.yaml
+++ b/spec/tsp-output/schema/openapi.yaml
@@ -73,6 +73,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Models.ErrorResponse'
+        '503':
+          description: Service unavailable.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Models.ErrorResponse'
       tags:
         - Auth
   /api/auth/me:
@@ -90,6 +96,12 @@ paths:
                 $ref: '#/components/schemas/Models.MeResponse'
         '401':
           description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Models.ErrorResponse'
+        '503':
+          description: Service unavailable.
           content:
             application/json:
               schema:

--- a/ui/lib/api/schema.d.ts
+++ b/ui/lib/api/schema.d.ts
@@ -1573,6 +1573,15 @@ export interface operations {
                     "application/json": components["schemas"]["Models.ErrorResponse"];
                 };
             };
+            /** @description Service unavailable. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Models.ErrorResponse"];
+                };
+            };
         };
     };
     getMe: {
@@ -1595,6 +1604,15 @@ export interface operations {
             };
             /** @description Access is unauthorized. */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Models.ErrorResponse"];
+                };
+            };
+            /** @description Service unavailable. */
+            503: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -106,6 +106,12 @@ Set `CACHE_PROVIDER` to `redis` or `valkey` for any multi-instance deployment. B
 
 An unrecognised value is rejected at startup rather than falling back to `memory`, since a silent fallback would reintroduce exactly the problems above.
 
+### Behaviour during a cache outage
+
+If the configured cache becomes unreachable, both login and authenticated requests return `503`. Sessions live in the cache, so while it is down there is no way to tell a valid session from an expired one — reporting `401` would send users to a login page that cannot succeed either, and would disguise an outage as an ordinary logout. A `401` therefore continues to mean what it says: the session is genuinely absent or expired. Unauthenticated routes are unaffected.
+
+A corrupt rate-limit counter — a value under a `rate_limit:` key that is not a counter — is reset automatically and logged at `WARN`. Only GenKitKraft writes that namespace, so if you see one, something else is writing to the same keyspace: check for a shared cache instance or a stray client.
+
 :::note
 The cache is not durable storage. Losing it logs users out and clears rate-limit counters, but no application data is affected — that lives in the database. Persistence is not required.
 


### PR DESCRIPTION
Two follow-ups from the review of #38, each deferred there because the fix churns more than the bug it accompanies.

## #40 — cache adapters heal corrupt counters silently

When a `rate_limit:` key holds a non-counter, both adapters reset it to a fresh counter rather than erroring. That recovery is correct and stays (on Redis a leftover string may carry no TTL, so erroring would lock an IP out permanently). But it was silent, and only GenKitKraft writes that namespace — a foreign value means a bug or another writer on the keyspace, exactly what an operator wants to know. The reset now logs at Warn.

- Both `NewCache` constructors take a `zerolog.Logger` (last param, by value), wired from the composition root.
- **In-memory:** `IncrementInt64` reaches the same reset path on absent, expired, *or* corrupt keys — logging there would Warn on every first login from every IP. It now reads the key back and logs only a genuine non-counter.
- **Redis:** the heal happens inside the Lua script, which returned `1` for both a heal and a normal first create. The script now returns `{n, healed}` so the Go side can tell them apart.

## #41 — a cache outage reported 503 at login but 401 everywhere else

`cache.Cache.Get` had no error return, so a Redis outage read as a miss and `memory_session.Validate` reported it as 401, while login returned 503 (its rate limiter's `Increment` does return an error). The user was bounced between "you're logged out" and "we're broken".

- `Get` gains an `error` return across the port, the scoped wrapper, and both adapters. A genuine miss stays a miss; only a backend failure is an error.
- `Validate` maps a genuine error to `Unavailable` (503); a real miss still returns 401.
- `web_fetch` treats a `Get` error as a miss and re-fetches — it's a pure cache.
- **Auth middleware:** it previously hardcoded 401 on any `GetMe` error, which would have made this fix inert on `/api/auth/me` and `/api/auth/logout` (this middleware, not the session store, emits those 401s). It now honours `Unavailable` and fails closed on everything else.
- Spec declares 503 on `me` and `logout`, matching `login`.

## Testing

- `go build`, `go vet`, `go vet -tags integration` all clean.
- Unit tests pass, including new coverage: in-memory heal-logging (with negative cases for first-create and expiry), `memory_session` outage→503, web_fetch error→re-fetch, and the auth-middleware 503/401/fail-closed cases.
- **Integration suite passed against real Redis and Valkey containers** — the `{n, healed}` script and the `Get` miss/outage split are only exercised here.

Closes #40
Closes #41